### PR TITLE
updating Behavior fields

### DIFF
--- a/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.GradientDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -35,10 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
-
-import de.hdodenhof.circleimageview.CircleImageView;
 
 public class GoalTryActivity extends ActionBarActivity implements
         BehaviorLoaderListener {
@@ -104,7 +100,7 @@ public class GoalTryActivity extends ActionBarActivity implements
                 ((TryGoalViewHolder) viewHolder).titleTextView.setText(behavior
                         .getTitle());
                 ((TryGoalViewHolder) viewHolder).descriptionTextView
-                        .setText(behavior.getNarrativeBlock());
+                        .setText(behavior.getMoreInfo());
                 if (mExpandedPositions.contains(Integer.valueOf(i))) {
                     ((TryGoalViewHolder) viewHolder).descriptionTextView.setVisibility(View
                             .VISIBLE);

--- a/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
@@ -1,21 +1,5 @@
 package org.tndata.android.grow.activity;
 
-import java.util.ArrayList;
-
-import org.tndata.android.grow.GrowApplication;
-import org.tndata.android.grow.R;
-import org.tndata.android.grow.model.Behavior;
-import org.tndata.android.grow.model.Category;
-import org.tndata.android.grow.model.Goal;
-import org.tndata.android.grow.task.BehaviorLoaderTask;
-import org.tndata.android.grow.task.BehaviorLoaderTask.BehaviorLoaderListener;
-import org.tndata.android.grow.ui.SpacingItemDecoration;
-import org.tndata.android.grow.ui.parallaxrecyclerview.HeaderLayoutManagerFixed;
-import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter;
-import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter.OnClickEvent;
-import org.tndata.android.grow.util.Constants;
-import org.tndata.android.grow.util.ImageCache;
-
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Color;
@@ -35,6 +19,22 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import org.tndata.android.grow.GrowApplication;
+import org.tndata.android.grow.R;
+import org.tndata.android.grow.model.Behavior;
+import org.tndata.android.grow.model.Category;
+import org.tndata.android.grow.model.Goal;
+import org.tndata.android.grow.task.BehaviorLoaderTask;
+import org.tndata.android.grow.task.BehaviorLoaderTask.BehaviorLoaderListener;
+import org.tndata.android.grow.ui.SpacingItemDecoration;
+import org.tndata.android.grow.ui.parallaxrecyclerview.HeaderLayoutManagerFixed;
+import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter;
+import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter.OnClickEvent;
+import org.tndata.android.grow.util.Constants;
+import org.tndata.android.grow.util.ImageCache;
+
+import java.util.ArrayList;
 
 public class GoalTryActivity extends ActionBarActivity implements
         BehaviorLoaderListener {
@@ -100,7 +100,7 @@ public class GoalTryActivity extends ActionBarActivity implements
                 ((TryGoalViewHolder) viewHolder).titleTextView.setText(behavior
                         .getTitle());
                 ((TryGoalViewHolder) viewHolder).descriptionTextView
-                        .setText(behavior.getMoreInfo());
+                        .setText(behavior.getDescription());
                 if (mExpandedPositions.contains(Integer.valueOf(i))) {
                     ((TryGoalViewHolder) viewHolder).descriptionTextView.setVisibility(View
                             .VISIBLE);

--- a/src/main/java/org/tndata/android/grow/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/grow/fragment/LearnMoreFragment.java
@@ -1,23 +1,22 @@
 package org.tndata.android.grow.fragment;
 
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
 import org.tndata.android.grow.GrowApplication;
 import org.tndata.android.grow.R;
 import org.tndata.android.grow.model.Behavior;
 import org.tndata.android.grow.model.Category;
 import org.tndata.android.grow.model.Goal;
 import org.tndata.android.grow.util.ImageHelper;
-
-import android.app.Activity;
-import android.app.Fragment;
-import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.View.OnClickListener;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
 public class LearnMoreFragment extends Fragment {
     private Behavior mBehavior;
@@ -88,7 +87,7 @@ public class LearnMoreFragment extends Fragment {
         });
 
         titleTextView.setText(mBehavior.getTitle());
-        descriptionTextView.setText(mBehavior.getDescription());
+        descriptionTextView.setText(mBehavior.getMoreInfo());
         return v;
     }
 

--- a/src/main/java/org/tndata/android/grow/model/Action.java
+++ b/src/main/java/org/tndata/android/grow/model/Action.java
@@ -8,7 +8,7 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     private Behavior behavior = null;
     private int behavior_id = -1;
     private int sequence_order = -1;
-    private String narrative_block = "";
+    private String more_info = "";
     private String external_resource = "";
     private String notification_text = "";
     private String icon_url = "";
@@ -18,12 +18,12 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     }
 
     public Action(int id, int order, String title, String titleSlug,
-                  String description, int sequenceOrder, String narrativeBlock,
+                  String description, int sequenceOrder, String moreInfo,
                   String externalResource, String notificationText, String iconUrl,
                   String imageUrl, int behaviorId) {
         super(id, title, titleSlug, description);
         this.sequence_order = sequenceOrder;
-        this.narrative_block = narrativeBlock;
+        this.more_info = moreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -33,12 +33,12 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
 
     public Action(int id, int order, String title, String titleSlug,
                   String description, Behavior behavior, int sequenceOrder,
-                  String narrativeBlock, String externalResource,
+                  String moreInfo, String externalResource,
                   String notificationText, String iconUrl, String imageUrl, int behaviorId) {
         super(id, title, titleSlug, description);
         this.behavior = behavior;
         this.sequence_order = sequenceOrder;
-        this.narrative_block = narrativeBlock;
+        this.more_info = moreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -62,12 +62,12 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
         this.sequence_order = sequence_order;
     }
 
-    public String getNarrativeBlock() {
-        return narrative_block;
+    public String getMoreInfo() {
+        return more_info;
     }
 
-    public void setNarrativeBlock(String narrative_block) {
-        this.narrative_block = narrative_block;
+    public void setMoreInfo(String more_info    ) {
+        this.more_info = more_info;
     }
 
     public String getExternalResource() {

--- a/src/main/java/org/tndata/android/grow/model/Behavior.java
+++ b/src/main/java/org/tndata/android/grow/model/Behavior.java
@@ -2,13 +2,12 @@ package org.tndata.android.grow.model;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
 
 public class Behavior extends TDCBase implements Serializable,
         Comparable<Behavior> {
 
     private static final long serialVersionUID = 7747989797893422842L;
-    private String narrative_block = "";
+    private String more_info = "";
     private String external_resource = "";
     private String notification_text = "";
     private String icon_url = "";
@@ -19,10 +18,10 @@ public class Behavior extends TDCBase implements Serializable,
     }
 
     public Behavior(int id, int order, String title, String titleSlug,
-                    String description, String narrativeBlock, String externalResource,
+                    String description, String moreInfo, String externalResource,
                     String notificationText, String iconUrl, String imageUrl) {
         super(id, title, titleSlug, description);
-        this.narrative_block = narrativeBlock;
+        this.more_info = moreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -30,11 +29,11 @@ public class Behavior extends TDCBase implements Serializable,
     }
 
     public Behavior(int id, int order, String title, String titleSlug,
-                    String description, String narrativeBlock, String externalResource,
+                    String description, String moreInfo, String externalResource,
                     String notificationText, String iconUrl, String imageUrl,
                     ArrayList<Goal> goals) {
         super(id, title, titleSlug, description);
-        this.narrative_block = narrativeBlock;
+        this.more_info = moreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -42,12 +41,12 @@ public class Behavior extends TDCBase implements Serializable,
         this.goals = goals;
     }
 
-    public String getNarrativeBlock() {
-        return narrative_block;
+    public String getMoreInfo() {
+        return more_info;
     }
 
-    public void setNarrativeBlock(String narrative_block) {
-        this.narrative_block = narrative_block;
+    public void setMoreInfo(String more_info) {
+        this.more_info = more_info;
     }
 
     public String getExternalResource() {


### PR DESCRIPTION
We've changed some of the fields on the back-end for behaviors and actions. We're changing the purpose of the `description` field, and we've renamed `narrative_block` to `more_info`.

We want `Behavior.description` to show in the card (this is the first bit of extra text the user sees), and then the `Behavior.more_info` field should be used when the user taps *More Info*.

This PR should implement those changes.

I'm not sure why Android Studio made all the import changes, though.