### PR TITLE
Don't try to set the visibility on null Views

### DIFF
--- a/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
@@ -172,12 +172,19 @@ public class GoalTryActivity extends ActionBarActivity implements
         }
         mAdapter.setOnClickEvent(new OnClickEvent() {
 
+            private void setVisibility(View v, int visibility) {
+                if(v != null) {
+                    v.setVisibility(visibility);
+                }
+            }
+
             @Override
             public void onClick(View v, int position) {
-                v.findViewById(R.id.list_item_behavior_try_it_button).setVisibility(View.VISIBLE);
-                v.findViewById(R.id.list_item_behavior_description_textview).setVisibility(View
-                        .VISIBLE);
-                v.findViewById(R.id.list_item_behavior_imageview).setVisibility(View.GONE);
+                setVisibility(v.findViewById(R.id.list_item_behavior_try_it_button), View.VISIBLE);
+                setVisibility(v.findViewById(R.id.list_item_behavior_try_it_button), View.VISIBLE);
+                setVisibility(v.findViewById(R.id.list_item_behavior_description_textview),
+                        View.VISIBLE);
+                setVisibility(v.findViewById(R.id.list_item_behavior_imageview), View.GONE);
                 mExpandedPositions.add(Integer.valueOf(position));
             }
         });

--- a/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/grow/activity/GoalTryActivity.java
@@ -33,6 +33,7 @@ import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter;
 import org.tndata.android.grow.ui.parallaxrecyclerview.ParallaxRecyclerAdapter.OnClickEvent;
 import org.tndata.android.grow.util.Constants;
 import org.tndata.android.grow.util.ImageCache;
+import org.tndata.android.grow.util.ViewHelper;
 
 import java.util.ArrayList;
 
@@ -172,19 +173,20 @@ public class GoalTryActivity extends ActionBarActivity implements
         }
         mAdapter.setOnClickEvent(new OnClickEvent() {
 
-            private void setVisibility(View v, int visibility) {
-                if(v != null) {
-                    v.setVisibility(visibility);
-                }
-            }
-
             @Override
             public void onClick(View v, int position) {
-                setVisibility(v.findViewById(R.id.list_item_behavior_try_it_button), View.VISIBLE);
-                setVisibility(v.findViewById(R.id.list_item_behavior_try_it_button), View.VISIBLE);
-                setVisibility(v.findViewById(R.id.list_item_behavior_description_textview),
+                ViewHelper.setVisibility(
+                        v.findViewById(R.id.list_item_behavior_try_it_button),
                         View.VISIBLE);
-                setVisibility(v.findViewById(R.id.list_item_behavior_imageview), View.GONE);
+                ViewHelper.setVisibility(
+                        v.findViewById(R.id.list_item_behavior_try_it_button),
+                        View.VISIBLE);
+                ViewHelper.setVisibility(
+                        v.findViewById(R.id.list_item_behavior_description_textview),
+                        View.VISIBLE);
+                ViewHelper.setVisibility(
+                        v.findViewById(R.id.list_item_behavior_imageview),
+                        View.GONE);
                 mExpandedPositions.add(Integer.valueOf(position));
             }
         });

--- a/src/main/java/org/tndata/android/grow/util/ViewHelper.java
+++ b/src/main/java/org/tndata/android/grow/util/ViewHelper.java
@@ -1,0 +1,19 @@
+package org.tndata.android.grow.util;
+
+import android.view.View;
+
+public class ViewHelper {
+    public final static int SELECTED = 1;
+    public final static int ADD = 2;
+
+    /**
+     * Helper method to set the visibility for a View, but only if the view is
+     * not null.
+     */
+    public static void setVisibility(View v, int visibility) {
+        if(v != null) {
+            v.setVisibility(visibility);
+        }
+    }
+
+}

--- a/src/main/java/org/tndata/android/grow/util/ViewHelper.java
+++ b/src/main/java/org/tndata/android/grow/util/ViewHelper.java
@@ -3,8 +3,6 @@ package org.tndata.android.grow.util;
 import android.view.View;
 
 public class ViewHelper {
-    public final static int SELECTED = 1;
-    public final static int ADD = 2;
 
     /**
      * Helper method to set the visibility for a View, but only if the view is


### PR DESCRIPTION
This fixes the issue where the app would crash when tapping on the `GoalTryActivity`'s description.

I'd love feedback on this @kevinzetterstrom when you're available. Does anything I'm doing here strike you as odd?

