### PR TITLE
Replace the MainActivity's default tab with Category cards containing the compass widget

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/MainActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/MainActivity.java
@@ -70,6 +70,20 @@ public class MainActivity extends ActionBarActivity implements
     private ImageView mHeaderImageView;
     private MainViewPagerAdapter mAdapter;
     private boolean mDrawerIsOpen = false;
+    private boolean backButtonSelectsDefaultTab = false;
+    private static final int DEFAULT_TAB = 0;
+
+    @Override
+    public void onBackPressed() {
+        // This activity may switch tabs when a user taps a card, so after doing that,
+        // we want the back button to return the user to the default tab.
+        if(backButtonSelectsDefaultTab) {
+            activateTab(DEFAULT_TAB);
+            backButtonSelectsDefaultTab = false; // resets default behavior
+        } else {
+            super.onBackPressed();
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -379,5 +393,15 @@ public class MainActivity extends ActionBarActivity implements
             sendBroadcast(intent);
             Log.d("Main Activity", "send broadcast");
         }
+    }
+
+    public void activateTab(int tabIndex) {
+        mViewPager.setCurrentItem(tabIndex);
+    }
+
+    @Override
+    public void transitionToCategoryTab(Category category) {
+        backButtonSelectsDefaultTab = true;
+        activateTab(mAdapter.getCategoryPosition(category) + 1);  // add one for the default tab
     }
 }

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -23,7 +23,6 @@ import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.ui.ActionListView;
 import org.tndata.android.compass.ui.BehaviorListView;
-import org.tndata.android.compass.util.ImageCache;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -103,12 +102,11 @@ public class CategoryFragmentAdapter extends
             ((CategoryGoalViewHolder) viewHolder).circleView
                     .setBackgroundDrawable(gradientDrawable);
         }
-        if (goal.getIconUrl() != null
-                && !goal.getIconUrl().isEmpty()) {
-            ImageCache.instance(mContext).loadBitmap(
-                    ((CategoryGoalViewHolder) viewHolder).iconImageView,
-                    goal.getIconUrl(), false);
-        }
+
+        // Set the progress widget for the Goal.
+        ((CategoryGoalViewHolder) viewHolder).iconImageView.setImageResource(
+                goal.getProgressIcon());
+
         ((CategoryGoalViewHolder) viewHolder).goalContainer.setOnClickListener(new View
                 .OnClickListener() {
 

--- a/src/main/java/org/tndata/android/compass/adapter/MainViewPagerAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MainViewPagerAdapter.java
@@ -47,7 +47,7 @@ public class MainViewPagerAdapter extends FragmentStatePagerAdapter {
     @Override
     public CharSequence getPageTitle(int position) {
         if (position == 0) {
-            return mContext.getResources().getString(R.string.my_goals_title)
+            return mContext.getResources().getString(R.string.main_tab_title)
                     .toUpperCase();
         } else {
             return mCategories.get(position - 1).getTitle().toUpperCase();

--- a/src/main/java/org/tndata/android/compass/adapter/MainViewPagerAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MainViewPagerAdapter.java
@@ -1,17 +1,17 @@
 package org.tndata.android.compass.adapter;
 
-import java.util.ArrayList;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
 
 import org.tndata.android.compass.R;
 import org.tndata.android.compass.fragment.CategoryFragment;
 import org.tndata.android.compass.fragment.MyGoalsFragment;
 import org.tndata.android.compass.model.Category;
 
-import android.annotation.SuppressLint;
-import android.content.Context;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentStatePagerAdapter;
+import java.util.ArrayList;
 
 public class MainViewPagerAdapter extends FragmentStatePagerAdapter {
     private Context mContext;
@@ -60,6 +60,10 @@ public class MainViewPagerAdapter extends FragmentStatePagerAdapter {
         } else {
             return mCategories.get(position - 1).getImageUrl();
         }
+    }
+
+    public int getCategoryPosition(Category category) {
+        return mCategories.indexOf(category);
     }
 
 }

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -49,7 +49,7 @@ public class MyGoalsAdapter extends
         TextView titleTextView;
         TextView subTitleTextView;
         RelativeLayout circleView;
-        LinearLayout noGoalsContainer;
+        LinearLayout categoryContainer;
         ImageView imageView;
 
         public MyGoalsViewHolder(View view) {
@@ -60,8 +60,8 @@ public class MyGoalsAdapter extends
                     .findViewById(R.id.list_item_my_goals_category_title_textview);
             subTitleTextView = (TextView) view
                     .findViewById(R.id.list_item_my_goals_category_add_textview);
-            noGoalsContainer = (LinearLayout) view.findViewById(R.id
-                    .list_item_my_goals_category_no_goals_container);
+            categoryContainer = (LinearLayout) view.findViewById(R.id
+                    .list_item_my_goals_category_container);
             imageView = (ImageView) view.findViewById(
                     R.id.list_item_my_goals_category_icon_imageview);
         }
@@ -130,10 +130,9 @@ public class MyGoalsAdapter extends
                                 .setBackgroundDrawable(gradientDrawable);
                     }
                     ((MyGoalsViewHolder) viewHolder).imageView.setImageResource(category.getProgressIcon());
-                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setVisibility(View.VISIBLE);
                     ((MyGoalsViewHolder) viewHolder).titleTextView.setText(category.getTitle());
                     ((MyGoalsViewHolder) viewHolder).subTitleTextView.setVisibility(View.GONE);
-                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setOnClickListener(new View
+                    ((MyGoalsViewHolder) viewHolder).categoryContainer.setOnClickListener(new View
                             .OnClickListener() {
 
                         @Override
@@ -159,12 +158,11 @@ public class MyGoalsAdapter extends
                         ((MyGoalsViewHolder) viewHolder).circleView
                                 .setBackgroundDrawable(gradientDrawable);
                     }
-                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setVisibility(View.VISIBLE);
                     ((MyGoalsViewHolder) viewHolder).titleTextView.setVisibility(View.GONE);
                     ((MyGoalsViewHolder) viewHolder).subTitleTextView.setText(mContext.getString
                             (R.string.category_goals_add,
                                     category.getTitle()));
-                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setOnClickListener(new View
+                    ((MyGoalsViewHolder) viewHolder).categoryContainer.setOnClickListener(new View
                             .OnClickListener() {
 
 

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -6,7 +6,6 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -39,6 +38,8 @@ public class MyGoalsAdapter extends
         public void chooseGoals(Category category);
 
         public void chooseBehaviors(Goal goal, Category category);
+
+        public void activateCategoryTab(Category category);
     }
 
     private Context mContext;
@@ -151,9 +152,8 @@ public class MyGoalsAdapter extends
 
                         @Override
                         public void onClick(View v) {
-                            // TODO: How to select & activate a tab?
-                            //mCallback.?
-                            Log.d("MyGoalsAdapter", "Tapped Category Card: " + category.getTitle() + " -- " + position);
+                            // Select & activate a Category Tab
+                            mCallback.activateCategoryTab(category);
                         }
                     });
 

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -6,9 +6,11 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -19,7 +21,6 @@ import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.model.MyGoalsViewItem;
 import org.tndata.android.compass.model.Survey;
-import org.tndata.android.compass.ui.GoalCellView;
 import org.tndata.android.compass.util.Constants;
 
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ public class MyGoalsAdapter extends
         RelativeLayout circleView;
         LinearLayout noGoalsContainer;
         LinearLayout goalContainer;
+        ImageView imageView;
 
         public MyGoalsViewHolder(View view) {
             super(view);
@@ -63,6 +65,8 @@ public class MyGoalsAdapter extends
                     .list_item_my_goals_category_no_goals_container);
             goalContainer = (LinearLayout) view.findViewById(R.id
                     .list_item_my_goals_category_goals_container);
+            imageView = (ImageView) view.findViewById(
+                    R.id.list_item_my_goals_category_icon_imageview);
         }
     }
 
@@ -112,23 +116,41 @@ public class MyGoalsAdapter extends
             case MyGoalsViewItem.TYPE_CATEGORY:
                 final Category category = mItems.get(position).getCategory();
                 ArrayList<Goal> goals = category.getGoals();
-                ((MyGoalsViewHolder) viewHolder).titleTextView.setText(mContext.getString(R
-                        .string.category_goals, category.getTitle()));
                 ((MyGoalsViewHolder) viewHolder).goalContainer.removeAllViews();
+
+                // Check to see if the user has selected any goals for the category
                 if (goals != null && !goals.isEmpty()) {
-                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setVisibility(View.GONE);
-                    for (final Goal goal : goals) {
-                        GoalCellView goalCellView = new GoalCellView(mContext);
-                        goalCellView.setGoal(goal, category);
-                        goalCellView.setOnClickListener(new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                mCallback.chooseBehaviors(goal, category);
-                            }
-                        });
-                        ((MyGoalsViewHolder) viewHolder).goalContainer.addView(goalCellView);
+                    ((MyGoalsViewHolder) viewHolder).goalContainer.setVisibility(View.GONE);
+                    GradientDrawable gradientDrawable = (GradientDrawable) ((MyGoalsViewHolder)
+                            viewHolder).circleView.getBackground();
+                    String colorString = category.getColor();
+                    if (colorString != null && !colorString.isEmpty()) {
+                        gradientDrawable.setColor(Color.parseColor(colorString));
                     }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                        ((MyGoalsViewHolder) viewHolder).circleView.setBackground
+                                (gradientDrawable);
+                    } else {
+                        ((MyGoalsViewHolder) viewHolder).circleView
+                                .setBackgroundDrawable(gradientDrawable);
+                    }
+                    ((MyGoalsViewHolder) viewHolder).imageView.setImageResource(category.getProgressIcon());
+                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setVisibility(View.VISIBLE);
+                    ((MyGoalsViewHolder) viewHolder).titleTextView.setText(category.getTitle());
+                    ((MyGoalsViewHolder) viewHolder).subTitleTextView.setVisibility(View.GONE);
+                    ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setOnClickListener(new View
+                            .OnClickListener() {
+
+                        @Override
+                        public void onClick(View v) {
+                            // TODO: How to select & activate a tab?
+                            //mCallback.?
+                            Log.d("MyGoalsAdapter", "Tapped Category Card: " + category.getTitle());
+                        }
+                    });
+
                 } else {
+
                     GradientDrawable gradientDrawable = (GradientDrawable) ((MyGoalsViewHolder)
                             viewHolder).circleView.getBackground();
                     String colorString = category.getColor();
@@ -143,6 +165,7 @@ public class MyGoalsAdapter extends
                                 .setBackgroundDrawable(gradientDrawable);
                     }
                     ((MyGoalsViewHolder) viewHolder).noGoalsContainer.setVisibility(View.VISIBLE);
+                    ((MyGoalsViewHolder) viewHolder).titleTextView.setVisibility(View.GONE);
                     ((MyGoalsViewHolder) viewHolder).subTitleTextView.setText(mContext.getString
                             (R.string.category_goals_add,
                                     category.getTitle()));

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -66,7 +66,21 @@ public class MyGoalsAdapter extends
                     R.id.list_item_my_goals_category_icon_imageview);
         }
 
-        public void setBackgroundColor(String colorString) {
+        public void setTitleText(String content) {
+            // Hide the subtitle, and display the title with the given text.
+            subTitleTextView.setVisibility(View.GONE);
+            titleTextView.setVisibility(View.VISIBLE);
+            titleTextView.setText(content);
+        }
+
+        public void setSubTitleText(String content) {
+            // Hide the title, and display the subtitle with the given text.
+            titleTextView.setVisibility(View.GONE);
+            subTitleTextView.setVisibility(View.VISIBLE);
+            subTitleTextView.setText(content);
+        }
+
+        public void setCircleViewBackgroundColor(String colorString) {
             GradientDrawable gradientDrawable = (GradientDrawable) circleView.getBackground();
 
             if (colorString != null && !colorString.isEmpty()) {
@@ -129,10 +143,9 @@ public class MyGoalsAdapter extends
 
                 // Check to see if the user has selected any goals for the category
                 if (goals != null && !goals.isEmpty()) {
-                    ((MyGoalsViewHolder) viewHolder).setBackgroundColor(category.getColor());
+                    ((MyGoalsViewHolder) viewHolder).setCircleViewBackgroundColor(category.getColor());
                     ((MyGoalsViewHolder) viewHolder).imageView.setImageResource(category.getProgressIcon());
-                    ((MyGoalsViewHolder) viewHolder).titleTextView.setText(category.getTitle());
-                    ((MyGoalsViewHolder) viewHolder).subTitleTextView.setVisibility(View.GONE);
+                    ((MyGoalsViewHolder) viewHolder).setTitleText(category.getTitle());
                     ((MyGoalsViewHolder) viewHolder).categoryContainer.setOnClickListener(new View
                             .OnClickListener() {
 
@@ -145,11 +158,9 @@ public class MyGoalsAdapter extends
                     });
 
                 } else {
-                    ((MyGoalsViewHolder) viewHolder).setBackgroundColor(category.getColor());
-                    ((MyGoalsViewHolder) viewHolder).titleTextView.setVisibility(View.GONE);
-                    ((MyGoalsViewHolder) viewHolder).subTitleTextView.setText(mContext.getString
-                            (R.string.category_goals_add,
-                                    category.getTitle()));
+                    ((MyGoalsViewHolder) viewHolder).setCircleViewBackgroundColor(category.getColor());
+                    ((MyGoalsViewHolder) viewHolder).setSubTitleText(mContext.getString
+                            (R.string.category_goals_add, category.getTitle()));
                     ((MyGoalsViewHolder) viewHolder).categoryContainer.setOnClickListener(new View
                             .OnClickListener() {
 

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -65,6 +65,19 @@ public class MyGoalsAdapter extends
             imageView = (ImageView) view.findViewById(
                     R.id.list_item_my_goals_category_icon_imageview);
         }
+
+        public void setBackgroundColor(String colorString) {
+            GradientDrawable gradientDrawable = (GradientDrawable) circleView.getBackground();
+
+            if (colorString != null && !colorString.isEmpty()) {
+                gradientDrawable.setColor(Color.parseColor(colorString));
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                circleView.setBackground(gradientDrawable);
+            } else {
+                circleView.setBackgroundDrawable(gradientDrawable);
+            }
+        }
     }
 
     static class MyGoalsNoContentViewHolder extends RecyclerView.ViewHolder {
@@ -116,19 +129,7 @@ public class MyGoalsAdapter extends
 
                 // Check to see if the user has selected any goals for the category
                 if (goals != null && !goals.isEmpty()) {
-                    GradientDrawable gradientDrawable = (GradientDrawable) ((MyGoalsViewHolder)
-                            viewHolder).circleView.getBackground();
-                    String colorString = category.getColor();
-                    if (colorString != null && !colorString.isEmpty()) {
-                        gradientDrawable.setColor(Color.parseColor(colorString));
-                    }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                        ((MyGoalsViewHolder) viewHolder).circleView.setBackground
-                                (gradientDrawable);
-                    } else {
-                        ((MyGoalsViewHolder) viewHolder).circleView
-                                .setBackgroundDrawable(gradientDrawable);
-                    }
+                    ((MyGoalsViewHolder) viewHolder).setBackgroundColor(category.getColor());
                     ((MyGoalsViewHolder) viewHolder).imageView.setImageResource(category.getProgressIcon());
                     ((MyGoalsViewHolder) viewHolder).titleTextView.setText(category.getTitle());
                     ((MyGoalsViewHolder) viewHolder).subTitleTextView.setVisibility(View.GONE);
@@ -139,25 +140,12 @@ public class MyGoalsAdapter extends
                         public void onClick(View v) {
                             // TODO: How to select & activate a tab?
                             //mCallback.?
-                            Log.d("MyGoalsAdapter", "Tapped Category Card: " + category.getTitle());
+                            Log.d("MyGoalsAdapter", "Tapped Category Card: " + category.getTitle() + " -- " + position);
                         }
                     });
 
                 } else {
-
-                    GradientDrawable gradientDrawable = (GradientDrawable) ((MyGoalsViewHolder)
-                            viewHolder).circleView.getBackground();
-                    String colorString = category.getColor();
-                    if (colorString != null && !colorString.isEmpty()) {
-                        gradientDrawable.setColor(Color.parseColor(colorString));
-                    }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                        ((MyGoalsViewHolder) viewHolder).circleView.setBackground
-                                (gradientDrawable);
-                    } else {
-                        ((MyGoalsViewHolder) viewHolder).circleView
-                                .setBackgroundDrawable(gradientDrawable);
-                    }
+                    ((MyGoalsViewHolder) viewHolder).setBackgroundColor(category.getColor());
                     ((MyGoalsViewHolder) viewHolder).titleTextView.setVisibility(View.GONE);
                     ((MyGoalsViewHolder) viewHolder).subTitleTextView.setText(mContext.getString
                             (R.string.category_goals_add,

--- a/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyGoalsAdapter.java
@@ -50,7 +50,6 @@ public class MyGoalsAdapter extends
         TextView subTitleTextView;
         RelativeLayout circleView;
         LinearLayout noGoalsContainer;
-        LinearLayout goalContainer;
         ImageView imageView;
 
         public MyGoalsViewHolder(View view) {
@@ -63,8 +62,6 @@ public class MyGoalsAdapter extends
                     .findViewById(R.id.list_item_my_goals_category_add_textview);
             noGoalsContainer = (LinearLayout) view.findViewById(R.id
                     .list_item_my_goals_category_no_goals_container);
-            goalContainer = (LinearLayout) view.findViewById(R.id
-                    .list_item_my_goals_category_goals_container);
             imageView = (ImageView) view.findViewById(
                     R.id.list_item_my_goals_category_icon_imageview);
         }
@@ -116,11 +113,9 @@ public class MyGoalsAdapter extends
             case MyGoalsViewItem.TYPE_CATEGORY:
                 final Category category = mItems.get(position).getCategory();
                 ArrayList<Goal> goals = category.getGoals();
-                ((MyGoalsViewHolder) viewHolder).goalContainer.removeAllViews();
 
                 // Check to see if the user has selected any goals for the category
                 if (goals != null && !goals.isEmpty()) {
-                    ((MyGoalsViewHolder) viewHolder).goalContainer.setVisibility(View.GONE);
                     GradientDrawable gradientDrawable = (GradientDrawable) ((MyGoalsViewHolder)
                             viewHolder).circleView.getBackground();
                     String colorString = category.getColor();

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -1,18 +1,5 @@
 package org.tndata.android.compass.fragment;
 
-import org.tndata.android.compass.CompassApplication;
-import org.tndata.android.compass.R;
-import org.tndata.android.compass.activity.BehaviorActivity;
-import org.tndata.android.compass.activity.ChooseGoalsActivity;
-import org.tndata.android.compass.activity.GoalTryActivity;
-import org.tndata.android.compass.adapter.CategoryFragmentAdapter;
-import org.tndata.android.compass.model.Behavior;
-import org.tndata.android.compass.model.Category;
-import org.tndata.android.compass.model.Goal;
-import org.tndata.android.compass.ui.SpacingItemDecoration;
-import org.tndata.android.compass.ui.button.FloatingActionButton;
-import org.tndata.android.compass.util.Constants;
-
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -27,6 +14,19 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.R;
+import org.tndata.android.compass.activity.BehaviorActivity;
+import org.tndata.android.compass.activity.ChooseGoalsActivity;
+import org.tndata.android.compass.activity.GoalTryActivity;
+import org.tndata.android.compass.adapter.CategoryFragmentAdapter;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.ui.SpacingItemDecoration;
+import org.tndata.android.compass.ui.button.FloatingActionButton;
+import org.tndata.android.compass.util.Constants;
+
 import java.util.ArrayList;
 
 public class CategoryFragment extends Fragment implements CategoryFragmentAdapter
@@ -39,11 +39,13 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
     private ArrayList<Goal> mItems = new ArrayList<Goal>();
     private boolean mBroadcastIsRegistered = false;
     private CategoryFragmentListener mCallback;
+    
+    private static final String TAG = "Category Fragment";
 
     private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            Log.d("Category Fragment", "receive broadcast");
+            Log.d(TAG, "receive broadcast");
             categoryGoalsUpdated();
         }
     };
@@ -137,7 +139,7 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
             getActivity().getApplicationContext().registerReceiver(broadcastReceiver,
                     new IntentFilter(Constants.GOAL_UPDATED_BROADCAST_ACTION));
             mBroadcastIsRegistered = true;
-            Log.d("Category Fragment", "Broadcast registered");
+            Log.d(TAG, "Broadcast registered");
         }
     }
 
@@ -161,7 +163,7 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.d("Category Fragment", "onActivityResult");
+        Log.d(TAG, "onActivityResult");
         if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
             mCallback.assignGoalsToCategories(true);
         } else if (resultCode == Constants.BEHAVIOR_CHANGED_RESULT_CODE) {
@@ -170,7 +172,7 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
     }
 
     public void categoryGoalsUpdated() {
-        Log.d("Category Fragment", "categoryGoalsUpdated");
+        Log.d(TAG, "categoryGoalsUpdated");
         for (Category category : ((CompassApplication) getActivity()
                 .getApplication()).getCategories()) {
             if (category.getId() == mCategory.getId()) {
@@ -184,7 +186,7 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
     }
 
     private void setGoals() {
-        Log.d("Category Fragment", "setGoals");
+        Log.d(TAG, "setGoals");
         ArrayList<Goal> goals = mCategory.getGoals();
         mItems.clear();
         if (goals != null && !goals.isEmpty()) {

--- a/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
@@ -266,6 +266,7 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
         }
     }
 
+    @Override
     public void activateCategoryTab(Category category) {
         mCallback.transitionToCategoryTab(category);
     }

--- a/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
@@ -47,6 +47,8 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
         public void chooseCategories();
 
         public void assignGoalsToCategories(boolean shouldSendBroadcast);
+
+        public void transitionToCategoryTab(Category category);
     }
 
     private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
@@ -259,9 +261,12 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.d("My Goals Fragment", "onActivityResult");
         if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
             mCallback.assignGoalsToCategories(true);
         }
+    }
+
+    public void activateCategoryTab(Category category) {
+        mCallback.transitionToCategoryTab(category);
     }
 }

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -1,5 +1,7 @@
 package org.tndata.android.compass.model;
 
+import org.tndata.android.compass.R;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -12,6 +14,7 @@ public class Category extends TDCBase implements Serializable,
     private String image_url = "";
     private ArrayList<Goal> goals = new ArrayList<Goal>();
     private String color = "";
+    private double progress_value = 0.0; // Only used for UserCategories
 
     public Category() {
     }
@@ -82,6 +85,37 @@ public class Category extends TDCBase implements Serializable,
 
     public void setColor(String color) {
         this.color = color;
+    }
+
+    public void setProgressValue(double value) {
+        this.progress_value = value;
+    }
+
+    public double getProgressValue() {
+        return this.progress_value;
+    }
+
+    public int getProgressIcon() {
+        double value = getProgressValue();
+        if (value < 0.125) {
+            return R.drawable.compass_9_s;
+        } else if (value < 0.25) {
+            return R.drawable.compass_8_sse;
+        } else if (value < 0.375) {
+            return R.drawable.compass_7_se;
+        } else if (value < 0.5) {
+            return R.drawable.compass_6_ees;
+        } else if (value < 0.625) {
+            return R.drawable.compass_5_e;
+        } else if (value < 0.75) {
+            return R.drawable.compass_4_nee;
+        } else if (value < 0.875) {
+            return R.drawable.compass_3_ne;
+        } else if (value < 0.95) {
+            return R.drawable.compass_2_nne;
+        } else {
+            return R.drawable.compass_1_n;
+        }
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/task/GetUserCategoriesTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserCategoriesTask.java
@@ -1,12 +1,11 @@
 package org.tndata.android.compass.task;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import android.os.AsyncTask;
+import android.text.Html;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -14,12 +13,13 @@ import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.util.Constants;
 import org.tndata.android.compass.util.NetworkHelper;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import android.os.AsyncTask;
-import android.text.Html;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GetUserCategoriesTask extends
         AsyncTask<String, Void, ArrayList<Category>> {
@@ -69,6 +69,7 @@ public class GetUserCategoriesTask extends
                 JSONObject userCategory = jArray.getJSONObject(i);
                 Category category = gson.fromJson(
                         userCategory.getString("category"), Category.class);
+                category.setProgressValue(userCategory.getDouble("progress_value"));
                 category.setMappingId(userCategory.getInt("id"));
                 categories.add(category);
             }

--- a/src/main/res/layout/list_item_my_goals_category.xml
+++ b/src/main/res/layout/list_item_my_goals_category.xml
@@ -19,7 +19,7 @@
         android:paddingTop="5dp">
 
         <LinearLayout
-            android:id="@+id/list_item_my_goals_category_no_goals_container"
+            android:id="@+id/list_item_my_goals_category_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal">

--- a/src/main/res/layout/list_item_my_goals_category.xml
+++ b/src/main/res/layout/list_item_my_goals_category.xml
@@ -18,21 +18,11 @@
         android:paddingRight="2dp"
         android:paddingTop="5dp">
 
-        <TextView
-            android:id="@+id/list_item_my_goals_category_title_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="5dp"
-            android:paddingLeft="2dp"
-            android:text="@string/category_goals"
-            android:textAppearance="?android:attr/textAppearanceMedium"/>
-
         <LinearLayout
             android:id="@+id/list_item_my_goals_category_no_goals_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_below="@id/list_item_my_goals_category_title_textview">
+            android:orientation="horizontal">
 
             <RelativeLayout
                 android:id="@+id/list_item_my_goals_category_circle_view"
@@ -55,6 +45,16 @@
                     android:layout_centerInParent="true"
                     android:src="@drawable/ic_action_compass_white"/>
             </RelativeLayout>
+
+            <TextView
+                android:id="@+id/list_item_my_goals_category_title_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="5dp"
+                android:paddingLeft="2dp"
+                android:gravity="center_vertical"
+                android:layout_gravity="center_vertical"
+                android:textAppearance="?android:attr/textAppearanceMedium"/>
 
             <TextView
                 android:id="@+id/list_item_my_goals_category_add_textview"

--- a/src/main/res/layout/list_item_my_goals_category.xml
+++ b/src/main/res/layout/list_item_my_goals_category.xml
@@ -68,14 +68,6 @@
                 android:textAppearance="?android:attr/textAppearanceSmall"/>
         </LinearLayout>
 
-        <LinearLayout
-            android:id="@+id/list_item_my_goals_category_goals_container"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_below="@id/list_item_my_goals_category_no_goals_container"></LinearLayout>
-
-
     </RelativeLayout>
 
 </android.support.v7.widget.CardView>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="action_my_priorities">My Priorities</string>
     <string name="action_my_privacy">My Privacy</string>
     <string name="nav_drawer_action">Compass</string>
-    <string name="my_goals_title">My Interests</string>
+    <string name="main_tab_title">My Journey</string>
 
     <!-- LoginActivity -->
     <string name="terms_title">Terms and Conditions</string>


### PR DESCRIPTION
Some background on this work is in [this trello card](https://trello.com/c/C7YpAmhk/55-home-screen-compass-widget-revision), but this just of this is:

* We want a single card for each category that the user has selected in the main activity's tab (now called  _My Journey_)
* If the user has selected any Goals within that Category, we show a widget representing the user's progress (pulled from the `progress_value` in the API)
* If the user has _not_ selected any goals, we keep the original behavior, which launches the `GoalTryActivity`
* Tapping on a Category should activate it's tab in the ViewPager
* After tapping on a category card, the back button should take you back to the original tab in the ViewPager.