### PR TITLE
Goal cards beneath Topic Tabs

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -143,7 +143,18 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.tndata.android.compass.activity.MainActivity"/>
         </activity>
-
+        <activity
+            android:name="org.tndata.android.compass.activity.GoalDetailsActivity"
+            android:parentActivityName="org.tndata.android.compass.activity.MainActivity"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.GET_CONTENT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.tndata.android.compass.activity.MainActivity"/>
+        </activity>
         <receiver
             android:name="org.tndata.android.compass.service.GcmBroadcastReceiver"
             android:permission="com.google.android.c2dm.permission.SEND">

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -32,6 +32,7 @@ public class GoalDetailsActivity extends ActionBarActivity implements
     private static final int GOALDETAIL = 0;
     private static final int LEARN_MORE_BEHAVIOR = 1;
     private static final int LEARN_MORE_ACTION = 2;
+    private static final int LEARN_MORE_GOAL = 3;
 
     private Toolbar mToolbar;
     private Category mCategory;
@@ -83,6 +84,12 @@ public class GoalDetailsActivity extends ActionBarActivity implements
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void learnMoreGoal(Goal goal) {
+        mGoal = goal;
+        swapFragments(LEARN_MORE_GOAL, true);
     }
 
     @Override
@@ -140,6 +147,11 @@ public class GoalDetailsActivity extends ActionBarActivity implements
                     fragment = mLearnMoreFragment;
                 }
                 break;
+            case LEARN_MORE_GOAL:
+                if(mGoal != null) {
+                    mLearnMoreFragment = LearnMoreFragment.newInstance(mGoal, mCategory);
+                    fragment = mLearnMoreFragment;
+                }
         }
         if (fragment != null) {
             if (addToStack) {

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -118,10 +118,15 @@ public class GoalDetailsActivity extends ActionBarActivity implements
     public void deleteGoal(Goal goal) {
         mFragmentStack.clear();
 
-        // Delete the goal.
+        // Delete the goal from the backend api.
         ArrayList<String> goals = new ArrayList<String>();
         goals.add(String.valueOf(goal.getMappingId()));
         new DeleteGoalTask(this, this, goals).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+
+        // Delete the goal from the Compass Application (will affect the UI)
+        ArrayList<Goal> applicationGoals = ((CompassApplication)getApplication()).getGoals();
+        applicationGoals.remove(goal);
+        ((CompassApplication) getApplication()).setGoals(applicationGoals);
 
         setResult(Constants.GOALS_CHANGED_RESULT_CODE);
     }

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -1,6 +1,7 @@
 package org.tndata.android.compass.activity;
 
 import android.app.Fragment;
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -88,6 +89,14 @@ public class GoalDetailsActivity extends ActionBarActivity implements
     @Override
     public void learnMoreAction(Action action) {
         swapFragments(LEARN_MORE_ACTION, true);
+    }
+
+    @Override
+    public void chooseBehaviors(Goal goal) {
+        Intent intent = new Intent(getApplicationContext(), GoalTryActivity.class);
+        intent.putExtra("goal", goal);
+        intent.putExtra("category", mCategory);
+        startActivityForResult(intent, Constants.CHOOSE_BEHAVIORS_REQUEST_CODE);
     }
 
     private void handleBackStack() {

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -1,0 +1,177 @@
+package org.tndata.android.compass.activity;
+
+import android.app.Fragment;
+import android.graphics.Color;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.KeyEvent;
+import android.view.MenuItem;
+
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.R;
+import org.tndata.android.compass.fragment.BehaviorFragment;
+import org.tndata.android.compass.fragment.GoalDetailsFragment;
+import org.tndata.android.compass.fragment.LearnMoreFragment;
+import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.task.DeleteBehaviorTask;
+import org.tndata.android.compass.util.Constants;
+
+import java.util.ArrayList;
+
+public class GoalDetailsActivity extends ActionBarActivity implements
+        //LearnMoreFragmentListener,
+        GoalDetailsFragment.GoalDetailsFragmentListener,
+        DeleteBehaviorTask.DeleteBehaviorTaskListener {
+
+    private static final int GOALDETAIL = 0;
+    private static final int LEARN_MORE_BEHAVIOR = 1;
+    private static final int LEARN_MORE_ACTION = 2;
+
+    private Toolbar mToolbar;
+    private Category mCategory;
+    private Goal mGoal;
+
+    private GoalDetailsFragment mGoalDetailsFragment = null;
+    private LearnMoreFragment mLearnMoreFragment = null;
+    private ArrayList<Fragment> mFragmentStack = new ArrayList<Fragment>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_base);
+
+        mCategory = (Category) getIntent().getSerializableExtra("category");
+        mGoal = (Goal) getIntent().getSerializableExtra("goal");
+
+        mToolbar = (Toolbar) findViewById(R.id.tool_bar);
+        mToolbar.setTitle(mGoal.getTitle());
+        mToolbar.getBackground().setAlpha(255);
+        mToolbar.setNavigationIcon(R.drawable.ic_arrow_back_white);
+        setSupportActionBar(mToolbar);
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+
+        if (mCategory != null && !mCategory.getColor().isEmpty()) {
+            mToolbar.setBackgroundColor(Color.parseColor(mCategory.getColor()));
+        }
+        swapFragments(GOALDETAIL, true);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if ((keyCode == KeyEvent.KEYCODE_BACK)) { // Back key pressed
+            handleBackStack();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                handleBackStack();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void learnMoreBehavior(Behavior behavior) {
+        swapFragments(LEARN_MORE_BEHAVIOR, true);
+    }
+
+    @Override
+    public void learnMoreAction(Action action) {
+        swapFragments(LEARN_MORE_ACTION, true);
+    }
+
+    private void handleBackStack() {
+        if (!mFragmentStack.isEmpty()) {
+            mFragmentStack.remove(mFragmentStack.size() - 1);
+        }
+
+        if (mFragmentStack.isEmpty()) {
+            finish();
+        } else {
+            swapFragments(GOALDETAIL, false);
+        }
+    }
+
+    private void swapFragments(int index, boolean addToStack) {
+        Fragment fragment = null;
+        switch (index) {
+            case GOALDETAIL:
+                if (mGoalDetailsFragment == null) {
+                    mGoalDetailsFragment = GoalDetailsFragment.newInstance(mCategory, mGoal);
+                }
+                fragment = mGoalDetailsFragment;
+                break;
+            case LEARN_MORE_BEHAVIOR:
+//                mLearnMoreFragment = LearnMoreFragment.newInstance(mBehavior, mCategory);
+//                fragment = mLearnMoreFragment;
+//                break;
+            case LEARN_MORE_ACTION:
+//                if (mAction != null) {
+//                    mLearnMoreFragment = LearnMoreFragment.newInstance(mAction, mBehavior,
+//                            mCategory);
+//                    fragment = mLearnMoreFragment;
+//                }
+//                break;
+        }
+        if (fragment != null) {
+            if (addToStack) {
+                mFragmentStack.add(fragment);
+            }
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.base_content, fragment).commit();
+        }
+    }
+
+    @Override
+    public void deleteBehavior(Behavior behavior) {
+        ArrayList<String> behaviors = new ArrayList<String>();
+        behaviors.add(String.valueOf(behavior.getMappingId()));
+        new DeleteBehaviorTask(this, this, behaviors).executeOnExecutor(AsyncTask
+                .THREAD_POOL_EXECUTOR);
+        ArrayList<Behavior> goalBehaviors = mGoal.getBehaviors();
+        goalBehaviors.remove(behavior);
+        mGoal.setBehaviors(goalBehaviors);
+        ArrayList<Goal> goals = new ArrayList<Goal>();
+        goals.addAll(((CompassApplication) getApplication()).getGoals());
+        for (Goal goal : goals) {
+            if (goal.getId() == mGoal.getId()) {
+                goal.setBehaviors(goalBehaviors);
+                break;
+            }
+        }
+        ((CompassApplication) getApplication()).setGoals(goals);
+        setResult(Constants.BEHAVIOR_CHANGED_RESULT_CODE);
+    }
+
+    @Override
+    public void behaviorsDeleted() {
+        if (!mFragmentStack.isEmpty()) {
+            Fragment fragment = mFragmentStack.get(mFragmentStack.size() - 1);
+            if (fragment instanceof LearnMoreFragment) {
+                ((LearnMoreFragment) fragment).setImageView();
+            } else if (fragment instanceof BehaviorFragment) {
+                ((BehaviorFragment) fragment).setImageView();
+            }
+        }
+    }
+
+    @Override
+    public void actionChanged() {
+        setResult(Constants.BEHAVIOR_CHANGED_RESULT_CODE);
+    }
+
+    @Override
+    public void fireBehaviorPicker(Behavior behavior) {
+        //TODO
+    }
+}

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -25,7 +25,7 @@ import org.tndata.android.compass.util.Constants;
 import java.util.ArrayList;
 
 public class GoalDetailsActivity extends ActionBarActivity implements
-        //LearnMoreFragmentListener,
+        LearnMoreFragment.LearnMoreFragmentListener,
         GoalDetailsFragment.GoalDetailsFragmentListener,
         DeleteBehaviorTask.DeleteBehaviorTaskListener {
 
@@ -36,6 +36,10 @@ public class GoalDetailsActivity extends ActionBarActivity implements
     private Toolbar mToolbar;
     private Category mCategory;
     private Goal mGoal;
+
+    // A user may tap an action or behavior to see more info
+    private Behavior mSelectedBehavior;
+    private Action mSelectedAction;
 
     private GoalDetailsFragment mGoalDetailsFragment = null;
     private LearnMoreFragment mLearnMoreFragment = null;
@@ -83,11 +87,13 @@ public class GoalDetailsActivity extends ActionBarActivity implements
 
     @Override
     public void learnMoreBehavior(Behavior behavior) {
+        mSelectedBehavior = behavior;
         swapFragments(LEARN_MORE_BEHAVIOR, true);
     }
 
     @Override
     public void learnMoreAction(Action action) {
+        mSelectedAction = action;
         swapFragments(LEARN_MORE_ACTION, true);
     }
 
@@ -121,24 +127,31 @@ public class GoalDetailsActivity extends ActionBarActivity implements
                 fragment = mGoalDetailsFragment;
                 break;
             case LEARN_MORE_BEHAVIOR:
-//                mLearnMoreFragment = LearnMoreFragment.newInstance(mBehavior, mCategory);
-//                fragment = mLearnMoreFragment;
-//                break;
+                if(mSelectedBehavior != null) {
+                    mLearnMoreFragment = LearnMoreFragment.newInstance(mSelectedBehavior, mCategory);
+                    fragment = mLearnMoreFragment;
+                }
+                break;
             case LEARN_MORE_ACTION:
-//                if (mAction != null) {
-//                    mLearnMoreFragment = LearnMoreFragment.newInstance(mAction, mBehavior,
-//                            mCategory);
-//                    fragment = mLearnMoreFragment;
-//                }
-//                break;
+                if (mSelectedAction != null) {
+                    mSelectedBehavior = mSelectedAction.getBehavior();
+                    mLearnMoreFragment = LearnMoreFragment.newInstance(
+                            mSelectedAction, mSelectedBehavior, mCategory);
+                    fragment = mLearnMoreFragment;
+                }
+                break;
         }
         if (fragment != null) {
             if (addToStack) {
                 mFragmentStack.add(fragment);
             }
-            getFragmentManager().beginTransaction()
-                    .replace(R.id.base_content, fragment).commit();
+            getFragmentManager().beginTransaction().replace(R.id.base_content, fragment).commit();
         }
+    }
+
+    @Override
+    public void addBehavior(Behavior behavior) {
+        // TODO:
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -20,6 +20,7 @@ import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.task.DeleteBehaviorTask;
+import org.tndata.android.compass.task.DeleteGoalTask;
 import org.tndata.android.compass.util.Constants;
 
 import java.util.ArrayList;
@@ -27,7 +28,8 @@ import java.util.ArrayList;
 public class GoalDetailsActivity extends ActionBarActivity implements
         LearnMoreFragment.LearnMoreFragmentListener,
         GoalDetailsFragment.GoalDetailsFragmentListener,
-        DeleteBehaviorTask.DeleteBehaviorTaskListener {
+        DeleteBehaviorTask.DeleteBehaviorTaskListener,
+        DeleteGoalTask.DeleteGoalTaskListener {
 
     private static final int GOALDETAIL = 0;
     private static final int LEARN_MORE_BEHAVIOR = 1;
@@ -110,6 +112,26 @@ public class GoalDetailsActivity extends ActionBarActivity implements
         intent.putExtra("goal", goal);
         intent.putExtra("category", mCategory);
         startActivityForResult(intent, Constants.CHOOSE_BEHAVIORS_REQUEST_CODE);
+    }
+
+    @Override
+    public void deleteGoal(Goal goal) {
+        mFragmentStack.clear();
+
+        // Delete the goal.
+        ArrayList<String> goals = new ArrayList<String>();
+        goals.add(String.valueOf(goal.getMappingId()));
+        new DeleteGoalTask(this, this, goals).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+
+        setResult(Constants.GOALS_CHANGED_RESULT_CODE);
+    }
+
+    @Override
+    public void goalsDeleted() {
+        // Tell the parent that the user's selected goals have been updated.
+        Intent intent = new Intent(Constants.GOAL_UPDATED_BROADCAST_ACTION);
+        sendBroadcast(intent);
+        finish();
     }
 
     private void handleBackStack() {

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -17,7 +17,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.tndata.android.compass.R;
-import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 
@@ -27,8 +26,7 @@ public class CategoryFragmentAdapter extends
         RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public interface CategoryFragmentAdapterInterface {
         public void chooseBehaviors(Goal goal);
-
-        public void viewBehavior(Goal goal, Behavior behavior);
+        public void viewGoal(Goal goal);
     }
 
     static class CategoryGoalViewHolder extends RecyclerView.ViewHolder {
@@ -147,7 +145,7 @@ public class CategoryFragmentAdapter extends
             new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mCallback.chooseBehaviors(goal);
+                    mCallback.viewGoal(goal);
                 }
             }
         );

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -6,7 +6,6 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -67,9 +66,6 @@ public class CategoryFragmentAdapter extends
         }
 
         public void toggleCard() {
-
-            Log.d("CategoryFragmentAdapter", "Toggling Card");
-
             // If the card is collapsed, expand it; if it's expanded, collapse it.
             if(descriptionTextView.getVisibility() == View.GONE) {
                 circleView.setVisibility(View.GONE);

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.adapter;
 
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
@@ -15,16 +14,11 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.R;
-import org.tndata.android.compass.model.Action;
 import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
-import org.tndata.android.compass.ui.ActionListView;
-import org.tndata.android.compass.ui.BehaviorListView;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class CategoryFragmentAdapter extends
@@ -39,7 +33,6 @@ public class CategoryFragmentAdapter extends
         TextView titleTextView;
         RelativeLayout circleView;
         LinearLayout goalContainer;
-        LinearLayout behaviorContainer;
         ImageView iconImageView;
 
         public CategoryGoalViewHolder(View view) {
@@ -50,10 +43,20 @@ public class CategoryFragmentAdapter extends
                     .list_item_category_goal_circle_view);
             goalContainer = (LinearLayout) view.findViewById(R.id
                     .list_item_category_goal_goal_container);
-            behaviorContainer = (LinearLayout) view.findViewById(R.id
-                    .list_item_category_goal_behavior_container);
             iconImageView = (ImageView) view.findViewById(R.id
                     .list_item_category_goal_icon_imageview);
+        }
+
+        public void setCircleViewBackgroundColor(String colorString) {
+            GradientDrawable gradientDrawable = (GradientDrawable) circleView.getBackground();
+            if (colorString != null && !colorString.isEmpty()) {
+                gradientDrawable.setColor(Color.parseColor(colorString));
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                circleView.setBackground(gradientDrawable);
+            } else {
+                circleView.setBackgroundDrawable(gradientDrawable);
+            }
         }
     }
 
@@ -89,19 +92,8 @@ public class CategoryFragmentAdapter extends
                                  final int position) {
         final Goal goal = mItems.get(position);
         ((CategoryGoalViewHolder) viewHolder).titleTextView.setText(goal.getTitle());
-        GradientDrawable gradientDrawable = (GradientDrawable) ((CategoryGoalViewHolder)
-                viewHolder).circleView.getBackground();
-        String colorString = mCategory.getColor();
-        if (colorString != null && !colorString.isEmpty()) {
-            gradientDrawable.setColor(Color.parseColor(colorString));
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            ((CategoryGoalViewHolder) viewHolder).circleView.setBackground
-                    (gradientDrawable);
-        } else {
-            ((CategoryGoalViewHolder) viewHolder).circleView
-                    .setBackgroundDrawable(gradientDrawable);
-        }
+        ((CategoryGoalViewHolder) viewHolder).setCircleViewBackgroundColor(
+                mCategory.getColor());
 
         // Set the progress widget for the Goal.
         ((CategoryGoalViewHolder) viewHolder).iconImageView.setImageResource(
@@ -115,36 +107,6 @@ public class CategoryFragmentAdapter extends
                 mCallback.chooseBehaviors(goal);
             }
         });
-        ArrayList<Behavior> behaviors = goal.getBehaviors();
-        ((CategoryGoalViewHolder) viewHolder).behaviorContainer.removeAllViews();
-        if (behaviors != null && !behaviors.isEmpty()) {
-            for (final Behavior behavior : behaviors) {
-                BehaviorListView behaviorListView = new BehaviorListView(mContext);
-                behaviorListView.setBehavior(behavior, mCategory);
-                behaviorListView.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        mCallback.viewBehavior(goal, behavior);
-                    }
-                });
-                ((CategoryGoalViewHolder) viewHolder).behaviorContainer.addView(behaviorListView);
-                if (mContext instanceof Activity) {
-                    for (final Action action : ((CompassApplication) ((Activity) mContext)
-                            .getApplication()).getActions()) {
-                        if ((action.getBehavior() != null && action.getBehavior().equals(behavior))
-                                || (action.getBehavior_id() == behavior.getId())) {
-                            ActionListView actionListView = new ActionListView(mContext);
-                            actionListView.setAction(action);
-
-                            ((CategoryGoalViewHolder) viewHolder).behaviorContainer.addView
-                                    (actionListView);
-
-                        }
-                    }
-                }
-            }
-        }
-
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -49,6 +49,7 @@ public class CategoryFragmentAdapter extends
                     .list_item_category_goal_goal_container);
             iconImageView = (ImageView) view.findViewById(R.id
                     .list_item_category_goal_icon_imageview);
+
             moreInfoButton = (Button) view.findViewById(R.id
                     .list_item_category_goal_more_info_button);
         }
@@ -121,31 +122,22 @@ public class CategoryFragmentAdapter extends
                 mCategory.getColor());
         ((CategoryGoalViewHolder) viewHolder).iconImageView.setImageResource(
                 goal.getProgressIcon());
-        ((CategoryGoalViewHolder) viewHolder).goalContainer.setOnClickListener(new View
-                .OnClickListener() {
-
-            @Override
-            public void onClick(View v) {
-                ((CategoryGoalViewHolder) viewHolder).toggleCard();
-            }
-        });
-
-        // Since the descriptionTextView is outside of the goal_goal_container layout, it
-        // also needs a click handler, otherwise, tapping on the description doesn't do anything
-        ((CategoryGoalViewHolder) viewHolder).descriptionTextView.setOnClickListener(
-            new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    ((CategoryGoalViewHolder) viewHolder).toggleCard();
-                }
-            }
-        );
 
         ((CategoryGoalViewHolder) viewHolder).moreInfoButton.setOnClickListener(
             new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     mCallback.viewGoal(goal);
+                }
+            }
+        );
+
+        // Expand/Collapse the card when tapped
+        ((CategoryGoalViewHolder) viewHolder).itemView.setOnClickListener(
+            new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    ((CategoryGoalViewHolder) viewHolder).toggleCard();
                 }
             }
         );

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -6,9 +6,11 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -31,20 +33,26 @@ public class CategoryFragmentAdapter extends
 
     static class CategoryGoalViewHolder extends RecyclerView.ViewHolder {
         TextView titleTextView;
+        TextView descriptionTextView;
         RelativeLayout circleView;
         LinearLayout goalContainer;
         ImageView iconImageView;
+        Button moreInfoButton;
 
         public CategoryGoalViewHolder(View view) {
             super(view);
             titleTextView = (TextView) view.findViewById(R.id
                     .list_item_category_goal_title_textview);
+            descriptionTextView = (TextView) view.findViewById(R.id
+                    .list_item_category_goal_description_textview);
             circleView = (RelativeLayout) view.findViewById(R.id
                     .list_item_category_goal_circle_view);
             goalContainer = (LinearLayout) view.findViewById(R.id
                     .list_item_category_goal_goal_container);
             iconImageView = (ImageView) view.findViewById(R.id
                     .list_item_category_goal_icon_imageview);
+            moreInfoButton = (Button) view.findViewById(R.id
+                    .list_item_category_goal_more_info_button);
         }
 
         public void setCircleViewBackgroundColor(String colorString) {
@@ -58,6 +66,23 @@ public class CategoryFragmentAdapter extends
                 circleView.setBackgroundDrawable(gradientDrawable);
             }
         }
+
+        public void toggleCard() {
+
+            Log.d("CategoryFragmentAdapter", "Toggling Card");
+
+            // If the card is collapsed, expand it; if it's expanded, collapse it.
+            if(descriptionTextView.getVisibility() == View.GONE) {
+                circleView.setVisibility(View.GONE);
+                descriptionTextView.setVisibility(View.VISIBLE);
+                moreInfoButton.setVisibility(View.VISIBLE);
+            }else {
+                circleView.setVisibility(View.VISIBLE);
+                descriptionTextView.setVisibility(View.GONE);
+                moreInfoButton.setVisibility(View.GONE);
+            }
+        }
+
     }
 
     private Context mContext;
@@ -92,21 +117,40 @@ public class CategoryFragmentAdapter extends
                                  final int position) {
         final Goal goal = mItems.get(position);
         ((CategoryGoalViewHolder) viewHolder).titleTextView.setText(goal.getTitle());
+        ((CategoryGoalViewHolder) viewHolder).descriptionTextView.setText(
+                goal.getDescription());
         ((CategoryGoalViewHolder) viewHolder).setCircleViewBackgroundColor(
                 mCategory.getColor());
-
-        // Set the progress widget for the Goal.
         ((CategoryGoalViewHolder) viewHolder).iconImageView.setImageResource(
                 goal.getProgressIcon());
-
         ((CategoryGoalViewHolder) viewHolder).goalContainer.setOnClickListener(new View
                 .OnClickListener() {
 
             @Override
             public void onClick(View v) {
-                mCallback.chooseBehaviors(goal);
+                ((CategoryGoalViewHolder) viewHolder).toggleCard();
             }
         });
+
+        // Since the descriptionTextView is outside of the goal_goal_container layout, it
+        // also needs a click handler, otherwise, tapping on the description doesn't do anything
+        ((CategoryGoalViewHolder) viewHolder).descriptionTextView.setOnClickListener(
+            new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    ((CategoryGoalViewHolder) viewHolder).toggleCard();
+                }
+            }
+        );
+
+        ((CategoryGoalViewHolder) viewHolder).moreInfoButton.setOnClickListener(
+            new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mCallback.chooseBehaviors(goal);
+                }
+            }
+        );
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
@@ -10,7 +10,6 @@ import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.task.ActionLoaderTask;
 import org.tndata.android.compass.task.ActionLoaderTask.ActionLoaderListener;
-import org.tndata.android.compass.task.DeleteActionTask;
 import org.tndata.android.compass.ui.ActionCellView;
 import org.tndata.android.compass.util.ImageCache;
 import org.tndata.android.compass.util.ImageHelper;
@@ -214,7 +213,7 @@ public class BehaviorFragment extends Fragment implements ActionLoaderListener, 
         PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
         //Inflating the Popup using xml file
         popup.getMenuInflater()
-                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
+                .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -16,11 +16,10 @@ import android.view.ViewGroup;
 
 import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.R;
-import org.tndata.android.compass.activity.BehaviorActivity;
 import org.tndata.android.compass.activity.ChooseGoalsActivity;
+import org.tndata.android.compass.activity.GoalDetailsActivity;
 import org.tndata.android.compass.activity.GoalTryActivity;
 import org.tndata.android.compass.adapter.CategoryFragmentAdapter;
-import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.ui.SpacingItemDecoration;
@@ -204,10 +203,9 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
     }
 
     @Override
-    public void viewBehavior(Goal goal, Behavior behavior) {
+    public void viewGoal(Goal goal) {
         Intent intent = new Intent(getActivity().getApplicationContext(),
-                BehaviorActivity.class);
-        intent.putExtra("behavior", behavior);
+                GoalDetailsActivity.class);
         intent.putExtra("goal", goal);
         intent.putExtra("category", mCategory);
         startActivityForResult(intent, Constants.VIEW_BEHAVIOR_REQUEST_CODE);

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -163,9 +163,9 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(TAG, "onActivityResult");
-        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
-            mCallback.assignGoalsToCategories(true);
-        } else if (resultCode == Constants.BEHAVIOR_CHANGED_RESULT_CODE) {
+        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE ||
+                requestCode == Constants.BEHAVIOR_CHANGED_RESULT_CODE ||
+                requestCode == Constants.GOALS_CHANGED_RESULT_CODE) {
             mCallback.assignGoalsToCategories(true);
         }
     }
@@ -208,7 +208,7 @@ public class CategoryFragment extends Fragment implements CategoryFragmentAdapte
                 GoalDetailsActivity.class);
         intent.putExtra("goal", goal);
         intent.putExtra("category", mCategory);
-        startActivityForResult(intent, Constants.VIEW_BEHAVIOR_REQUEST_CODE);
+        startActivityForResult(intent, Constants.GOALS_CHANGED_RESULT_CODE);
     }
 
 }

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -6,10 +6,12 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -40,11 +42,13 @@ public class GoalDetailsFragment extends Fragment implements
     private LinearLayout mBehaviorActionsContainer;
     private ProgressBar mProgressBar;
     private GoalDetailsFragmentListener mCallback;
+    private ImageView mChooseMore;
     private Map<Behavior, ArrayList<Action>> mBehaviorActionMap = new HashMap<Behavior, ArrayList<Action>>();
 
     private static final String TAG = "GoalDetailsFragment";
 
     public interface GoalDetailsFragmentListener {
+        public void chooseBehaviors(Goal goal);
         public void learnMoreBehavior(Behavior behavior);
         public void learnMoreAction(Action action);
         public void deleteBehavior(Behavior behavior);
@@ -75,6 +79,14 @@ public class GoalDetailsFragment extends Fragment implements
                              Bundle savedInstanceState) {
         View v = getActivity().getLayoutInflater().inflate(
                 R.layout.fragment_goal_details, container, false);
+        mChooseMore = (ImageView) v.findViewById(R.id.goal_choose_more_imageview);
+        mChooseMore.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showPopup();
+            }
+        });
+
         TextView titleTextView = (TextView) v.findViewById(R.id.goal_title_textview);
         titleTextView.setText(mGoal.getTitle());
 
@@ -202,28 +214,24 @@ public class GoalDetailsFragment extends Fragment implements
     }
 
     private void showPopup() {
-//        //Creating the instance of PopupMenu
-//        PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
-//        //Inflating the Popup using xml file
-//        popup.getMenuInflater()
-//                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
-//
-//        //registering popup with OnMenuItemClickListener
-//        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
-//            public boolean onMenuItemClick(MenuItem item) {
-//                switch (item.getItemId()) {
-//                    case R.id.menu_popup_remove_item:
-//                            mCallback.deleteBehavior(mBehavior);
-//                        break;
-//                    case R.id.menu_popup_edit_item:
-//                            mCallback.fireBehaviorPicker(mBehavior);
-//                        break;
-//                }
-//                return true;
-//            }
-//        });
-//
-//        popup.show(); //showing popup menu
+        //Creating the instance of PopupMenu
+        PopupMenu popup = new PopupMenu(getActivity(), mChooseMore);
+        // TODO: create a new menu file with options for the goal
+        popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
+        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+            public boolean onMenuItemClick(MenuItem item) {
+                switch (item.getItemId()) {
+                    case R.id.menu_popup_add_behavior:
+                        mCallback.chooseBehaviors(mGoal);
+                        break;
+                    case R.id.menu_popup_remove_goal:
+                        // TODO: Do we really want to do this?
+                        break;
+                }
+                return true;
+            }
+        });
+        popup.show();
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -1,0 +1,248 @@
+package org.tndata.android.compass.fragment;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.R;
+import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.task.GetUserActionsTask;
+import org.tndata.android.compass.task.GetUserBehaviorsTask;
+import org.tndata.android.compass.ui.ActionCellView;
+import org.tndata.android.compass.ui.BehaviorListView;
+import org.tndata.android.compass.util.ImageCache;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GoalDetailsFragment extends Fragment implements
+        GetUserActionsTask.GetUserActionsListener,
+        GetUserBehaviorsTask.GetUserBehaviorsListener,
+        ActionCellView.ActionViewListener {
+
+    private Category mCategory;
+    private Goal mGoal;
+    private LinearLayout mBehaviorActionsContainer;
+    private ProgressBar mProgressBar;
+    private GoalDetailsFragmentListener mCallback;
+    private Map<Behavior, ArrayList<Action>> mBehaviorActionMap = new HashMap<Behavior, ArrayList<Action>>();
+
+    private static final String TAG = "GoalDetailsFragment";
+
+    public interface GoalDetailsFragmentListener {
+        public void learnMoreBehavior(Behavior behavior);
+        public void learnMoreAction(Action action);
+        public void deleteBehavior(Behavior behavior);
+        public void actionChanged();
+        public void fireBehaviorPicker(Behavior behavior);
+    }
+
+    public static GoalDetailsFragment newInstance(Category category, Goal goal) {
+        GoalDetailsFragment fragment = new GoalDetailsFragment();
+        Bundle args = new Bundle();
+        args.putSerializable("category", category);
+        args.putSerializable("goal", goal);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mCategory = getArguments() != null ? ((Category) getArguments().get(
+                "category")) : new Category();
+        mGoal = getArguments() != null ? ((Goal) getArguments().get(
+                "goal")) : new Goal();
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View v = getActivity().getLayoutInflater().inflate(
+                R.layout.fragment_goal_details, container, false);
+        TextView titleTextView = (TextView) v.findViewById(R.id.goal_title_textview);
+        titleTextView.setText(mGoal.getTitle());
+
+        RelativeLayout goalContentContainer = (RelativeLayout) v
+                .findViewById(R.id.goal_content_container);
+//        goalContentContainer.setOnClickListener(new OnClickListener() {
+//
+//            @Override
+//            public void onClick(View v) {
+//                mCallback.learnMoreBehavior();
+//            }
+//        });
+
+        if (mGoal.getIconUrl() != null && !mGoal.getIconUrl().isEmpty()) {
+            ImageView iconImageView = (ImageView) v.findViewById(R.id.goal_icon_imageview);
+            ImageCache.instance(getActivity().getApplicationContext()).loadBitmap(iconImageView,
+                    mGoal.getIconUrl(), false);
+
+        }
+        mProgressBar = (ProgressBar) v.findViewById(R.id.goal_progressbar);
+        mBehaviorActionsContainer = (LinearLayout) v.findViewById(R.id.behavior_actions_container);
+        return v;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        loadBehaviors();
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity); // This makes sure that the container activity
+        // has implemented the callback interface. If not, it throws an
+        // exception
+        try {
+            mCallback = (GoalDetailsFragmentListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString()
+                    + " must implement LearnMoreListener");
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mCallback = null;
+    }
+
+    private void loadBehaviors() {
+        new GetUserBehaviorsTask(this).executeOnExecutor(
+                AsyncTask.THREAD_POOL_EXECUTOR,
+                ((CompassApplication) getActivity().getApplication()).getToken(),
+                String.valueOf(mGoal.getId())
+        );
+    }
+
+    private void loadActions() {
+        new GetUserActionsTask(this).executeOnExecutor(
+                AsyncTask.THREAD_POOL_EXECUTOR,
+                ((CompassApplication) getActivity().getApplication()).getToken(),
+                String.valueOf(mGoal.getId()));
+    }
+
+    @Override
+    public void behaviorsLoaded(ArrayList<Behavior> behaviors) {
+        for(Behavior behavior : behaviors) {
+            mBehaviorActionMap.put(behavior, new ArrayList<Action>());
+        }
+        loadActions();
+    }
+
+    @Override
+    public void actionsLoaded(ArrayList<Action> actions) {
+
+        for(Behavior behavior : mBehaviorActionMap.keySet()) {
+            for (Action action : actions) {
+                if(action.getBehavior_id() == behavior.getId()) {
+                    mBehaviorActionMap.get(behavior).add(action);
+                }
+            }
+        }
+        drawBehaviorsAndActions();
+    }
+
+    private void drawBehaviorsAndActions() {
+
+        for (Map.Entry<Behavior, ArrayList<Action>> entry : mBehaviorActionMap.entrySet()) {
+            Behavior behavior = entry.getKey();
+            ArrayList<Action> actions = entry.getValue();
+
+            Log.d("Behavior", "*draw name: " + behavior.getTitle());
+            BehaviorListView behaviorListView = new BehaviorListView(getActivity());
+            behaviorListView.setBehavior(behavior, mCategory);
+            mBehaviorActionsContainer.addView(behaviorListView);
+
+            for (Action action : actions) {
+                Log.d("Action", "*draw name:" + action.getTitle());
+                ActionCellView acv = new ActionCellView(getActivity());
+                acv.setAction(action, mCategory);
+                acv.setListener(this);
+                mBehaviorActionsContainer.addView(acv);
+            }
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        setImageView();
+    }
+
+    public void setImageView() {
+//        for (Goal goal : ((CompassApplication) getActivity().getApplication()).getGoals()) {
+//            if (goal.getBehaviors().contains(mBehavior)) {
+//                ImageHelper.setupImageViewButton(getResources(), mAddImageView,
+//                        ImageHelper.CHOOSE);
+//                mProgressBar.setVisibility(View.GONE);
+//                mAddImageView.setEnabled(true);
+//                return;
+//            }
+//        }
+//        ImageHelper.setupImageViewButton(getResources(), mAddImageView, ImageHelper.ADD);
+        mProgressBar.setVisibility(View.GONE);
+    }
+
+    private void showPopup() {
+//        //Creating the instance of PopupMenu
+//        PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
+//        //Inflating the Popup using xml file
+//        popup.getMenuInflater()
+//                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
+//
+//        //registering popup with OnMenuItemClickListener
+//        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+//            public boolean onMenuItemClick(MenuItem item) {
+//                switch (item.getItemId()) {
+//                    case R.id.menu_popup_remove_item:
+//                            mCallback.deleteBehavior(mBehavior);
+//                        break;
+//                    case R.id.menu_popup_edit_item:
+//                            mCallback.fireBehaviorPicker(mBehavior);
+//                        break;
+//                }
+//                return true;
+//            }
+//        });
+//
+//        popup.show(); //showing popup menu
+    }
+
+    @Override
+    public void actionChanged(Action action) {
+        mCallback.actionChanged();
+//        ArrayList<Action> actions = ((CompassApplication) getActivity().getApplication()
+//        ).getActions();
+//        if (actions.contains(action)) {
+//            for (Goal goal : ((CompassApplication) getActivity().getApplication()).getGoals()) {
+//                if (goal.getBehaviors().contains(mBehavior)) {
+//                    return;
+//                }
+//            }
+//            mCallback.addBehavior(mBehavior);
+//        }
+    }
+
+    @Override
+    public void fireActionPicker() {
+
+    }
+}

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -48,6 +48,7 @@ public class GoalDetailsFragment extends Fragment implements
 
     public interface GoalDetailsFragmentListener {
         public void chooseBehaviors(Goal goal);
+        public void learnMoreGoal(Goal goal);
         public void learnMoreBehavior(Behavior behavior);
         public void learnMoreAction(Action action);
         public void deleteBehavior(Behavior behavior);
@@ -88,6 +89,14 @@ public class GoalDetailsFragment extends Fragment implements
 
         TextView titleTextView = (TextView) v.findViewById(R.id.goal_title_textview);
         titleTextView.setText(mGoal.getTitle());
+
+        TextView goalManagementLabel = (TextView) v.findViewById(R.id.goal_management_label);
+        goalManagementLabel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mCallback.learnMoreGoal(mGoal);
+            }
+        });
 
         RelativeLayout goalContentContainer = (RelativeLayout) v
                 .findViewById(R.id.goal_content_container);

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -49,6 +49,7 @@ public class GoalDetailsFragment extends Fragment implements
 
     public interface GoalDetailsFragmentListener {
         public void chooseBehaviors(Goal goal);
+        public void deleteGoal(Goal goal);
         public void learnMoreGoal(Goal goal);
         public void learnMoreBehavior(Behavior behavior);
         public void learnMoreAction(Action action);
@@ -224,6 +225,8 @@ public class GoalDetailsFragment extends Fragment implements
                     case R.id.menu_popup_add_behavior:
                         mCallback.chooseBehaviors(mGoal);
                         break;
+                    case R.id.menu_popup_remove_goal:
+                        mCallback.deleteGoal(mGoal);
                 }
                 return true;
             }

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -92,19 +91,11 @@ public class GoalDetailsFragment extends Fragment implements
 
         RelativeLayout goalContentContainer = (RelativeLayout) v
                 .findViewById(R.id.goal_content_container);
-//        goalContentContainer.setOnClickListener(new OnClickListener() {
-//
-//            @Override
-//            public void onClick(View v) {
-//                mCallback.learnMoreBehavior();
-//            }
-//        });
 
         if (mGoal.getIconUrl() != null && !mGoal.getIconUrl().isEmpty()) {
             ImageView iconImageView = (ImageView) v.findViewById(R.id.goal_icon_imageview);
             ImageCache.instance(getActivity().getApplicationContext()).loadBitmap(iconImageView,
                     mGoal.getIconUrl(), false);
-
         }
         mProgressBar = (ProgressBar) v.findViewById(R.id.goal_progressbar);
         mBehaviorActionsContainer = (LinearLayout) v.findViewById(R.id.behavior_actions_container);
@@ -178,39 +169,29 @@ public class GoalDetailsFragment extends Fragment implements
             Behavior behavior = entry.getKey();
             ArrayList<Action> actions = entry.getValue();
 
-            Log.d("Behavior", "*draw name: " + behavior.getTitle());
             BehaviorListView behaviorListView = new BehaviorListView(getActivity());
             behaviorListView.setBehavior(behavior, mCategory);
+            behaviorListView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    mCallback.learnMoreBehavior(((BehaviorListView) view).getBehavior());
+                }
+            });
             mBehaviorActionsContainer.addView(behaviorListView);
 
             for (Action action : actions) {
-                Log.d("Action", "*draw name:" + action.getTitle());
                 ActionCellView acv = new ActionCellView(getActivity());
                 acv.setAction(action, mCategory);
                 acv.setListener(this);
+                acv.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        mCallback.learnMoreAction(((ActionCellView) view).getAction());
+                    }
+                });
                 mBehaviorActionsContainer.addView(acv);
             }
         }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        setImageView();
-    }
-
-    public void setImageView() {
-//        for (Goal goal : ((CompassApplication) getActivity().getApplication()).getGoals()) {
-//            if (goal.getBehaviors().contains(mBehavior)) {
-//                ImageHelper.setupImageViewButton(getResources(), mAddImageView,
-//                        ImageHelper.CHOOSE);
-//                mProgressBar.setVisibility(View.GONE);
-//                mAddImageView.setEnabled(true);
-//                return;
-//            }
-//        }
-//        ImageHelper.setupImageViewButton(getResources(), mAddImageView, ImageHelper.ADD);
-        mProgressBar.setVisibility(View.GONE);
     }
 
     private void showPopup() {

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -34,7 +34,8 @@ import java.util.Map;
 public class GoalDetailsFragment extends Fragment implements
         GetUserActionsTask.GetUserActionsListener,
         GetUserBehaviorsTask.GetUserBehaviorsListener,
-        ActionCellView.ActionViewListener {
+        ActionCellView.ActionViewListener,
+        BehaviorListView.BehaviorListViewListener {
 
     private Category mCategory;
     private Goal mGoal;
@@ -131,6 +132,13 @@ public class GoalDetailsFragment extends Fragment implements
     }
 
     @Override
+    public void onResume() {
+        // Let's reload all the fragment's data because it may have changed.
+        super.onResume();
+        loadBehaviors();
+    }
+
+    @Override
     public void onDetach() {
         super.onDetach();
         mCallback = null;
@@ -174,11 +182,14 @@ public class GoalDetailsFragment extends Fragment implements
 
     private void drawBehaviorsAndActions() {
 
+        mBehaviorActionsContainer.removeAllViews();
+
         for (Map.Entry<Behavior, ArrayList<Action>> entry : mBehaviorActionMap.entrySet()) {
             Behavior behavior = entry.getKey();
             ArrayList<Action> actions = entry.getValue();
 
             BehaviorListView behaviorListView = new BehaviorListView(getActivity());
+            behaviorListView.setListener(this);
             behaviorListView.setBehavior(behavior, mCategory);
             behaviorListView.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -206,16 +217,12 @@ public class GoalDetailsFragment extends Fragment implements
     private void showPopup() {
         //Creating the instance of PopupMenu
         PopupMenu popup = new PopupMenu(getActivity(), mChooseMore);
-        // TODO: create a new menu file with options for the goal
         popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_add_behavior:
                         mCallback.chooseBehaviors(mGoal);
-                        break;
-                    case R.id.menu_popup_remove_goal:
-                        // TODO: Do we really want to do this?
                         break;
                 }
                 return true;
@@ -225,18 +232,15 @@ public class GoalDetailsFragment extends Fragment implements
     }
 
     @Override
+    public void deleteUserBehavior(Behavior behavior) {
+        mCallback.deleteBehavior(behavior);
+        mBehaviorActionMap.remove(behavior);
+        drawBehaviorsAndActions();
+    }
+
+    @Override
     public void actionChanged(Action action) {
         mCallback.actionChanged();
-//        ArrayList<Action> actions = ((CompassApplication) getActivity().getApplication()
-//        ).getActions();
-//        if (actions.contains(action)) {
-//            for (Goal goal : ((CompassApplication) getActivity().getApplication()).getGoals()) {
-//                if (goal.getBehaviors().contains(mBehavior)) {
-//                    return;
-//                }
-//            }
-//            mCallback.addBehavior(mBehavior);
-//        }
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -223,7 +223,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
         PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
         //Inflating the Popup using xml file
         popup.getMenuInflater()
-                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
+                .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 
 public class LearnMoreFragment extends Fragment implements AddActionTask
         .AddActionTaskListener, DeleteActionTask.DeleteActionTaskListener {
+    private Goal mGoal;
     private Behavior mBehavior;
     private Category mCategory;
     private Action mAction;
@@ -51,6 +52,19 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
 
     public void setCategory(Category category) {
         mCategory = category;
+    }
+
+    public void setGoal(Goal goal) {
+        mGoal = goal;
+    }
+
+    public static LearnMoreFragment newInstance(Goal goal, Category category) {
+        LearnMoreFragment fragment = new LearnMoreFragment();
+        Bundle args = new Bundle();
+        args.putSerializable("goal", goal);
+        args.putSerializable("category", category);
+        fragment.setArguments(args);
+        return fragment;
     }
 
     public static LearnMoreFragment newInstance(Behavior behavior, Category category) {
@@ -82,6 +96,8 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 "behavior")) : new Behavior();
         mCategory = getArguments() != null ? ((Category) getArguments().get(
                 "category")) : new Category();
+        mGoal = getArguments() != null ? ((Goal) getArguments().get(
+                "goal")) : new Goal();
     }
 
     @Override
@@ -135,6 +151,12 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             titleTextView.setText(mAction.getTitle());
             descriptionTextView.setText(mAction.getDescription());
             addLabelTextView.setText(getText(R.string.action_i_want_this_label));
+        } else if (mGoal != null) {
+            // this is a learn more screen for a Goal
+            titleTextView.setText(mGoal.getTitle());
+            descriptionTextView.setText(mGoal.getDescription());
+            addLabelTextView.setVisibility(View.GONE);
+            mAddImageView.setVisibility(View.GONE);
         } else {
             // this is a learn more screen for a Behavior
             titleTextView.setText(mBehavior.getTitle());
@@ -180,7 +202,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 mAddImageView.setEnabled(true);
                 return;
             }
-        } else {
+        } else if (mBehavior != null) {
             for (Goal goal : ((CompassApplication) getActivity().getApplication()).getGoals()) {
                 if (goal.getBehaviors().contains(mBehavior)) {
                     ImageHelper.setupImageViewButton(getResources(), mAddImageView,

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -38,7 +38,16 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
     @Override
     protected ArrayList<Action> doInBackground(String... params) {
         String token = params[0];
+        String goalFilter = null;
+
+        if(params.length == 2) {
+            goalFilter = params[1];
+        }
         String url = Constants.BASE_URL + "users/actions/";
+        if(goalFilter != null) {
+            url = url + "?goal=" + goalFilter;
+        }
+
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Accept", "application/json");
         headers.put("Content-type", "application/json");

--- a/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
@@ -38,7 +38,16 @@ public class GetUserBehaviorsTask extends AsyncTask<String, Void, ArrayList<Beha
     @Override
     protected ArrayList<Behavior> doInBackground(String... params) {
         String token = params[0];
+        String goalFilter = null;
+
+        if(params.length == 2) {
+            goalFilter = params[1];
+        }
         String url = Constants.BASE_URL + "users/behaviors/";
+        if(goalFilter != null) {
+            url = url + "?goal=" + goalFilter;
+        }
+
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Accept", "application/json");
         headers.put("Content-type", "application/json");

--- a/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
+++ b/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
@@ -1,14 +1,5 @@
 package org.tndata.android.compass.ui;
 
-import org.tndata.android.compass.CompassApplication;
-import org.tndata.android.compass.R;
-import org.tndata.android.compass.model.Action;
-import org.tndata.android.compass.model.Category;
-import org.tndata.android.compass.task.AddActionTask;
-import org.tndata.android.compass.task.DeleteActionTask;
-import org.tndata.android.compass.util.ImageCache;
-import org.tndata.android.compass.util.ImageHelper;
-
 import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
@@ -20,6 +11,14 @@ import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.R;
+import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.task.AddActionTask;
+import org.tndata.android.compass.task.DeleteActionTask;
+import org.tndata.android.compass.util.ImageHelper;
 
 import java.util.ArrayList;
 
@@ -150,10 +149,6 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
     private void updateUi() {
         try {
             mTitleTextView.setText(mAction.getTitle());
-            if (mAction.getIconUrl() != null) {
-                ImageCache.instance(getContext()).loadBitmap(mImageView,
-                        mAction.getIconUrl(), false);
-            }
             updateImage();
         } catch (Exception e) {
             e.printStackTrace();
@@ -166,11 +161,10 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
 
     public void updateImage() {
         if (mContext instanceof Activity) {
-            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext).getApplication()
-            ).getActions();
+            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext)
+                    .getApplication()).getActions();
             if (actions.contains(mAction)) {
-                ImageHelper.setupImageViewButton(getResources(), mAddImageView,
-                        ImageHelper.CHOOSE);
+                ImageHelper.setupImageViewButton(getResources(), mAddImageView, ImageHelper.CHOOSE);
             } else {
                 ImageHelper.setupImageViewButton(getResources(), mAddImageView, ImageHelper.ADD);
             }
@@ -187,8 +181,8 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
 
         mAction = action;
         if (mContext instanceof Activity) {
-            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext).getApplication()
-            ).getActions();
+            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext)
+                    .getApplication()).getActions();
 
             actions.add(mAction);
             ((CompassApplication) ((Activity) mContext).getApplication()).setActions(actions);
@@ -205,8 +199,8 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
         mProgressBar.setVisibility(View.GONE);
         mAddImageView.setEnabled(true);
         if (mContext instanceof Activity) {
-            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext).getApplication()
-            ).getActions();
+            ArrayList<Action> actions = ((CompassApplication) ((Activity) mContext)
+                    .getApplication()).getActions();
             actions.remove(mAction);
             ((CompassApplication) ((Activity) mContext).getApplication()).setActions(actions);
         }

--- a/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
+++ b/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
@@ -95,7 +95,7 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
         PopupMenu popup = new PopupMenu(mContext, mAddImageView);
         //Inflating the Popup using xml file
         popup.getMenuInflater()
-                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
+                .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
+++ b/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
@@ -2,9 +2,12 @@ package org.tndata.android.compass.ui;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.Log;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import org.tndata.android.compass.R;
@@ -14,10 +17,14 @@ import org.tndata.android.compass.util.ImageCache;
 
 public class BehaviorListView extends LinearLayout {
     private ImageView mIconImageView;
+    private ImageView mAddImageView;
     private TextView mTitleTextView;
     private Behavior mBehavior;
     private Category mCategory;
     private Context mContext;
+
+    // TODO: Implement a GoalDetailsViewListener (similar to ActionCellView.ActionViewListener)
+    // TODO: that way I can call methods on the fragment when an item from the popup menu is selected.
 
     public BehaviorListView(Context context) {
         this(context, null);
@@ -36,9 +43,15 @@ public class BehaviorListView extends LinearLayout {
         mContext = context;
         View view = inflate(context, R.layout.view_behavior_item, this);
 
+        mTitleTextView = (TextView) view.findViewById(R.id.view_behavior_textview);
         mIconImageView = (ImageView) view.findViewById(R.id.view_behavior_icon_imageview);
-        mTitleTextView = (TextView) view
-                .findViewById(R.id.view_behavior_textview);
+        mAddImageView = (ImageView) view.findViewById(R.id.view_behavior_add_imageview);
+        mAddImageView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showPopup();
+            }
+        });
         if (mBehavior != null) {
             updateUi();
         }
@@ -63,6 +76,32 @@ public class BehaviorListView extends LinearLayout {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void showPopup() {
+        //Creating the instance of PopupMenu
+        PopupMenu popup = new PopupMenu(mContext, mAddImageView);
+        //Inflating the Popup using xml file
+        popup.getMenuInflater()
+                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
+
+        //registering popup with OnMenuItemClickListener
+        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+            public boolean onMenuItemClick(MenuItem item) {
+                switch (item.getItemId()) {
+                    case R.id.menu_popup_remove_item:
+                        //deleteUserAction();
+                        Log.d("BehaviorListView", "Remove Behavior... ");
+                        break;
+                    case R.id.menu_popup_edit_item:
+                        //mCallback.fireActionPicker();
+                        Log.d("BehaviorListView", "Edit Behavior Reminder....");
+                        break;
+                }
+                return true;
+            }
+        });
+        popup.show(); //showing popup menu
     }
 
     public Behavior getBehavior() {

--- a/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
+++ b/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
@@ -2,7 +2,6 @@ package org.tndata.android.compass.ui;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
@@ -22,9 +21,15 @@ public class BehaviorListView extends LinearLayout {
     private Behavior mBehavior;
     private Category mCategory;
     private Context mContext;
+    private BehaviorListViewListener mCallback;
 
-    // TODO: Implement a GoalDetailsViewListener (similar to ActionCellView.ActionViewListener)
-    // TODO: that way I can call methods on the fragment when an item from the popup menu is selected.
+    public interface BehaviorListViewListener {
+        public void deleteUserBehavior(Behavior behavior);
+    }
+
+    public void setListener(BehaviorListViewListener listener) {
+        mCallback = listener;
+    }
 
     public BehaviorListView(Context context) {
         this(context, null);
@@ -81,21 +86,13 @@ public class BehaviorListView extends LinearLayout {
     private void showPopup() {
         //Creating the instance of PopupMenu
         PopupMenu popup = new PopupMenu(mContext, mAddImageView);
-        //Inflating the Popup using xml file
         popup.getMenuInflater()
-                .inflate(R.menu.menu_popup_chooser, popup.getMenu());
-
-        //registering popup with OnMenuItemClickListener
+                .inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
-                    case R.id.menu_popup_remove_item:
-                        //deleteUserAction();
-                        Log.d("BehaviorListView", "Remove Behavior... ");
-                        break;
-                    case R.id.menu_popup_edit_item:
-                        //mCallback.fireActionPicker();
-                        Log.d("BehaviorListView", "Edit Behavior Reminder....");
+                    case R.id.menu_behavior_popup_remove_item:
+                        mCallback.deleteUserBehavior(mBehavior);
                         break;
                 }
                 return true;

--- a/src/main/java/org/tndata/android/compass/util/Constants.java
+++ b/src/main/java/org/tndata/android/compass/util/Constants.java
@@ -8,6 +8,7 @@ public class Constants {
     public final static int VIEW_BEHAVIOR_REQUEST_CODE = 2204;
     public final static int BEHAVIOR_CHANGED_RESULT_CODE = 2205;
     public final static int CHOOSE_BEHAVIORS_REQUEST_CODE = 2206;
+    public final static int GOALS_CHANGED_RESULT_CODE = 2207;
 
     public final static int QOL_INSTRUMENT_ID = 1;
     public final static int BIO_INSTRUMENT_ID = 4;

--- a/src/main/res/drawable/circle_dark_gray.xml
+++ b/src/main/res/drawable/circle_dark_gray.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid
+        android:angle="270"
+        android:color="@color/dark_text_color"/>
+</shape>

--- a/src/main/res/drawable/circle_gray.xml
+++ b/src/main/res/drawable/circle_gray.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="oval">
+    <solid
+        android:angle="270"
+        android:color="@android:color/darker_gray"/>
+</shape>

--- a/src/main/res/layout/fragment_goal_details.xml
+++ b/src/main/res/layout/fragment_goal_details.xml
@@ -1,0 +1,85 @@
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="fill_parent">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:paddingLeft="@dimen/default_activity_padding"
+        android:paddingRight="@dimen/default_activity_padding"
+        android:paddingTop="@dimen/behavior_fragments_top_padding">
+
+        <TextView
+            android:id="@+id/goal_title_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentTop="true"
+            android:text="@string/goal_title_label"
+            android:textAppearance="?android:attr/textAppearanceLarge"/>
+
+        <RelativeLayout
+            android:id="@+id/goal_content_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/goal_title_textview"
+            android:layout_marginTop="50dp">
+
+            <ImageView
+                android:id="@+id/goal_icon_imageview"
+                android:layout_width="@dimen/action_item_image_size"
+                android:layout_height="@dimen/action_item_image_size"
+                android:layout_alignParentLeft="true"
+                android:contentDescription="@string/action_image_description"
+                android:layout_margin="5dp"
+                android:src="@drawable/ic_action_compass_white"
+                android:background="@drawable/circle_gray"
+                android:scaleType="fitCenter"
+                android:padding="5dp" />
+
+            <ProgressBar
+                android:id="@+id/goal_progressbar"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/behavior_add_to_priorities_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_marginLeft="10dp"
+                android:layout_toRightOf="@id/goal_icon_imageview"
+                android:text="@string/goal_management"
+                android:textColor="@color/dark_text_color"
+                android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+        </RelativeLayout>
+
+        <View
+            android:id="@+id/goal_take_action_below_separator"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@id/goal_content_container"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="10dp"
+            android:background="@color/disabled_text_color"/>
+
+        <LinearLayout
+            android:id="@+id/behavior_actions_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/goal_take_action_below_separator"
+            android:animateLayoutChanges="true"
+            android:orientation="vertical"
+            android:paddingLeft="0dp"
+            android:paddingRight="0dp"
+            android:layout_margin="0dp">
+
+            <!-- Dynamically add elements here -->
+        </LinearLayout>
+    </RelativeLayout>
+</ScrollView>

--- a/src/main/res/layout/fragment_goal_details.xml
+++ b/src/main/res/layout/fragment_goal_details.xml
@@ -47,7 +47,7 @@
                 android:visibility="gone"/>
 
             <TextView
-                android:id="@+id/behavior_add_to_priorities_label"
+                android:id="@+id/goal_management_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"

--- a/src/main/res/layout/fragment_goal_details.xml
+++ b/src/main/res/layout/fragment_goal_details.xml
@@ -57,6 +57,16 @@
                 android:textColor="@color/dark_text_color"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
 
+            <ImageView
+                android:id="@+id/goal_choose_more_imageview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_margin="0dp"
+                android:padding="0dp"
+                android:src="@drawable/ic_more_vert"
+                android:layout_centerVertical="true" />
+
         </RelativeLayout>
 
         <View

--- a/src/main/res/layout/list_item_category_goal.xml
+++ b/src/main/res/layout/list_item_category_goal.xml
@@ -57,11 +57,5 @@
                 android:textColor="@color/dark_text_color"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
         </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/list_item_category_goal_behavior_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"></LinearLayout>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/src/main/res/layout/list_item_category_goal.xml
+++ b/src/main/res/layout/list_item_category_goal.xml
@@ -80,9 +80,15 @@
             android:layout_margin="15dp"
             android:minHeight="@dimen/paper_flat_button_min_height"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="@drawable/button_paper_flat_text_selector"
-            android:background="@drawable/button_paper_flat"
+            android:textColor="@color/grow_primary"
             android:text="@string/learn_more_title_label"
+            android:background="@color/white"
+            android:elevation="0dp"
+            android:elegantTextHeight="false"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:singleLine="true"
+            android:textColorHighlight="@color/white"
             android:visibility="gone"/>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/src/main/res/layout/list_item_category_goal.xml
+++ b/src/main/res/layout/list_item_category_goal.xml
@@ -57,5 +57,32 @@
                 android:textColor="@color/dark_text_color"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
         </LinearLayout>
+
+        <TextView
+            android:id="@+id/list_item_category_goal_description_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:paddingLeft="5dp"
+            android:paddingRight="5dp"
+            android:textColor="@color/dark_text_color"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:singleLine="false"
+            android:gravity="left"
+            android:visibility="gone"/>
+
+        <Button
+            android:id="@+id/list_item_category_goal_more_info_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_gravity="right"
+            android:layout_margin="15dp"
+            android:minHeight="@dimen/paper_flat_button_min_height"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@drawable/button_paper_flat_text_selector"
+            android:background="@drawable/button_paper_flat"
+            android:text="@string/learn_more_title_label"
+            android:visibility="gone"/>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/src/main/res/layout/view_action_cell.xml
+++ b/src/main/res/layout/view_action_cell.xml
@@ -5,15 +5,17 @@
                 android:layout_marginTop="5dp"
                 android:layout_marginBottom="5dp">
 
+    <!--android:layout_width="@dimen/action_item_image_size"-->
     <ImageView
         android:id="@+id/view_action_imageview"
-        android:layout_width="@dimen/action_item_image_size"
-        android:layout_height="@dimen/action_item_image_size"
+        android:layout_width="@dimen/action_item_bullet_size"
+        android:layout_height="@dimen/action_item_bullet_size"
         android:layout_alignParentLeft="true"
+        android:layout_marginLeft="@dimen/action_item_offset"
+        android:layout_marginRight="@dimen/action_item_offset"
         android:contentDescription="@string/action_image_description"
-        android:layout_margin="5dp"
-        android:padding="5dp"
-        android:src="@drawable/ic_action_compass_white"/>
+        android:src="@drawable/circle_dark_gray"
+        android:layout_centerVertical="true" />
 
     <ImageView
         android:id="@+id/view_action_add_imageview"
@@ -21,8 +23,8 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:layout_margin="5dp"
-        android:padding="3dp"
+        android:layout_margin="0dp"
+        android:padding="0dp"
         android:adjustViewBounds="true"
         android:contentDescription="@string/action_image_description"
         android:scaleType="centerCrop"
@@ -47,13 +49,12 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_marginBottom="5dp"
-        android:layout_marginLeft="5dp"
-        android:layout_marginRight="5dp"
-        android:layout_marginTop="15dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
+        android:layout_marginTop="5dp"
         android:layout_toLeftOf="@id/view_action_add_imageview"
         android:layout_toRightOf="@id/view_action_imageview"
-        android:paddingLeft="2dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="@color/dark_text_color"/>
+        android:textColor="@color/dark_text_color" />
 
 </RelativeLayout>

--- a/src/main/res/layout/view_behavior_item.xml
+++ b/src/main/res/layout/view_behavior_item.xml
@@ -15,8 +15,9 @@
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
         android:src="@drawable/ic_action_compass_white"
-        android:layout_margin="10dp"
-        android:padding="5dp"/>
+        android:layout_margin="0dp"
+        android:paddingEnd="5dp"
+        android:paddingRight="5dp"/>
 
     <TextView
         android:id="@+id/view_behavior_textview"

--- a/src/main/res/layout/view_behavior_item.xml
+++ b/src/main/res/layout/view_behavior_item.xml
@@ -8,25 +8,48 @@
               android:layout_marginLeft="15dp"
               android:layout_marginBottom="8dp">
 
-    <ImageView
-        android:id="@+id/view_behavior_icon_imageview"
-        android:layout_width="@dimen/behavior_icon_image_size"
-        android:layout_height="@dimen/behavior_icon_image_size"
-        android:scaleType="centerCrop"
-        android:adjustViewBounds="true"
-        android:src="@drawable/ic_action_compass_white"
-        android:layout_margin="0dp"
-        android:paddingEnd="5dp"
-        android:paddingRight="5dp"/>
-
-    <TextView
-        android:id="@+id/view_behavior_textview"
-        android:layout_width="wrap_content"
+    <RelativeLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="5dp"
-        android:paddingLeft="5dp"
-        android:gravity="center_vertical"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/dark_text_color"
-        android:textAppearance="?android:attr/textAppearanceMedium"/>
+        android:id="@+id/view_behavior_container">
+
+        <ImageView
+            android:id="@+id/view_behavior_icon_imageview"
+            android:layout_width="@dimen/behavior_icon_image_size"
+            android:layout_height="@dimen/behavior_icon_image_size"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true"
+            android:src="@drawable/ic_action_compass_white"
+            android:layout_margin="0dp"
+            android:padding="0dp" />
+
+        <TextView
+            android:id="@+id/view_behavior_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="5dp"
+            android:paddingRight="0dp"
+            android:gravity="center_vertical"
+            android:layout_gravity="center_vertical|left"
+            android:textColor="@color/dark_text_color"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="@string/behavior_title_placeholder"
+            android:layout_toRightOf="@+id/view_behavior_icon_imageview"
+            android:lines="2"
+            android:maxLines="2"
+            android:singleLine="false"
+            android:layout_marginLeft="0dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginBottom="0dp"
+            android:layout_marginRight="30dp" />
+
+        <ImageView
+            android:id="@+id/view_behavior_add_imageview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_margin="0dp"
+            android:padding="0dp"
+            android:src="@drawable/ic_more_vert"/>
+    </RelativeLayout>
 </LinearLayout>

--- a/src/main/res/menu/menu_action_popup_chooser.xml
+++ b/src/main/res/menu/menu_action_popup_chooser.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+
+    <item
+        android:id="@+id/menu_popup_edit_item"
+        android:title="@string/menu_popup_edit"/>
+
+    <item
+        android:id="@+id/menu_popup_remove_item"
+        android:title="@string/menu_popup_remove"/>
+
+</menu>

--- a/src/main/res/menu/menu_behavior_popup_chooser.xml
+++ b/src/main/res/menu/menu_behavior_popup_chooser.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
+
     <item
-        android:id="@+id/menu_popup_edit_item"
-        android:title="@string/menu_popup_edit"/>
-    <item
-        android:id="@+id/menu_popup_remove_item"
+        android:id="@+id/menu_behavior_popup_remove_item"
         android:title="@string/menu_popup_remove"/>
+
 </menu>

--- a/src/main/res/menu/menu_goal_details.xml
+++ b/src/main/res/menu/menu_goal_details.xml
@@ -5,10 +5,8 @@
         android:id="@+id/menu_popup_add_behavior"
         android:title="@string/menu_goal_new_behaviors"/>
 
-    <!--
     <item
         android:id="@+id/menu_popup_remove_goal"
         android:title="@string/menu_goal_remove"/>
-    -->
 
 </menu>

--- a/src/main/res/menu/menu_goal_details.xml
+++ b/src/main/res/menu/menu_goal_details.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_popup_add_behavior"
+        android:title="@string/menu_goal_new_behaviors"/>
+
+    <item
+        android:id="@+id/menu_popup_remove_goal"
+        android:title="@string/menu_goal_remove"/>
+
+</menu>

--- a/src/main/res/menu/menu_goal_details.xml
+++ b/src/main/res/menu/menu_goal_details.xml
@@ -5,8 +5,10 @@
         android:id="@+id/menu_popup_add_behavior"
         android:title="@string/menu_goal_new_behaviors"/>
 
+    <!--
     <item
         android:id="@+id/menu_popup_remove_goal"
         android:title="@string/menu_goal_remove"/>
+    -->
 
 </menu>

--- a/src/main/res/menu/menu_popup_chooser.xml
+++ b/src/main/res/menu/menu_popup_chooser.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item
-        android:id="@+id/menu_popup_remove_item"
-        android:title="@string/menu_popup_remove"/>
-
     <item
         android:id="@+id/menu_popup_edit_item"
         android:title="@string/menu_popup_edit"/>
-
+    <item
+        android:id="@+id/menu_popup_remove_item"
+        android:title="@string/menu_popup_remove"/>
 </menu>

--- a/src/main/res/values/dimens.xml
+++ b/src/main/res/values/dimens.xml
@@ -13,6 +13,8 @@
     <dimen name="behavior_icon_image_size">45dp</dimen>
     <dimen name="category_small_icon_image_size">35dp</dimen>
     <dimen name="action_item_image_size">35dp</dimen>
+    <dimen name="action_item_bullet_size">15dp</dimen> <!-- size of the bullet next to Actions -->
+    <dimen name="action_item_offset">26dp</dimen> <!-- L/R margin for bullet; indents beneath behavior icon  -->
     <dimen name="behavior_fragments_top_padding">100dp</dimen>
     <dimen name="cardview_corner_radius">2dp</dimen>
     <dimen name="login_header_size">175dp</dimen>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -73,6 +73,10 @@
     <string name="category_goals">%1$s goals</string>
     <string name="category_goals_add">What are your %1$s goals?</string>
 
+    <!-- GoalDetailsActivity -->
+    <string name="goal_title_label">Achieve Your Goal</string>
+    <string name="goal_management">Manage Your Goal</string>
+
     <!-- BehaviorActivity -->
     <string name="learn_more_no_thanks">NO THANKS</string>
     <string name="learn_more_title_label">Learn more</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
     <!-- GoalDetailsActivity -->
     <string name="goal_title_label">Achieve Your Goal</string>
     <string name="goal_management">Achieve your Goal</string>
+    <string name="menu_goal_new_behaviors">Choose New Priorities</string>
+    <string name="menu_goal_remove">Remove Goal</string>
 
     <!-- BehaviorActivity -->
     <string name="learn_more_no_thanks">NO THANKS</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
 
     <!-- GoalDetailsActivity -->
     <string name="goal_title_label">Achieve Your Goal</string>
-    <string name="goal_management">Manage Your Goal</string>
+    <string name="goal_management">Achieve your Goal</string>
 
     <!-- BehaviorActivity -->
     <string name="learn_more_no_thanks">NO THANKS</string>
@@ -89,6 +89,7 @@
     <string name="action_i_want_this_label">I want this</string>
     <string name="menu_popup_remove">Remove</string>
     <string name="menu_popup_edit">Edit notification</string>
+    <string name="behavior_title_placeholder">This is a placeholder description for one of your selected Priorities</string>
 
     <!-- GoalTryActivity -->
     <string name="goal_try_these">TRY THESE</string>


### PR DESCRIPTION
**WIP** Do not merge this PR!

* This lists goal cards beneath each of the Category Tabs on the main screen
* Tapping a goal card expands it, and displays a _More Info_ button
* Tapping the more Info button displays the new `GoalDetailsActivity` which:
  * lists all of the user's selected `Behaviors` associated with the Goal
  * lists all of the user's selected `Actions` beneath each  `Behavior`.

Work left to do:

* list a bullet point next to each action instead of an icon
* pop  up mentions for each Behavior
* a pop up menu for actions related to the Goal (e.g. find more behaviors/actions, remove goal)

