### PR TITLE
Almost support Markdown?

### DIFF
--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -44,6 +44,7 @@ public class GoalDetailsFragment extends Fragment implements
     private GoalDetailsFragmentListener mCallback;
     private ImageView mChooseMore;
     private Map<Behavior, ArrayList<Action>> mBehaviorActionMap = new HashMap<Behavior, ArrayList<Action>>();
+    private Boolean reloadData = true;
 
     private static final String TAG = "GoalDetailsFragment";
 
@@ -116,7 +117,12 @@ public class GoalDetailsFragment extends Fragment implements
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        loadBehaviors();
+        if(reloadData) {
+            loadBehaviors();
+            reloadData = false;
+        } else {
+            drawBehaviorsAndActions();
+        }
     }
 
     @Override
@@ -130,13 +136,6 @@ public class GoalDetailsFragment extends Fragment implements
             throw new ClassCastException(activity.toString()
                     + " must implement LearnMoreListener");
         }
-    }
-
-    @Override
-    public void onResume() {
-        // Let's reload all the fragment's data because it may have changed.
-        super.onResume();
-        loadBehaviors();
     }
 
     @Override
@@ -173,7 +172,9 @@ public class GoalDetailsFragment extends Fragment implements
 
         for(Behavior behavior : mBehaviorActionMap.keySet()) {
             for (Action action : actions) {
-                if(action.getBehavior_id() == behavior.getId()) {
+                if(action.getBehavior_id() == behavior.getId() &&
+                        !mBehaviorActionMap.get(behavior).contains(action)) {
+
                     mBehaviorActionMap.get(behavior).add(action);
                 }
             }
@@ -182,7 +183,6 @@ public class GoalDetailsFragment extends Fragment implements
     }
 
     private void drawBehaviorsAndActions() {
-
         mBehaviorActionsContainer.removeAllViews();
 
         for (Map.Entry<Behavior, ArrayList<Action>> entry : mBehaviorActionMap.entrySet()) {

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -109,6 +109,10 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 .findViewById(R.id.learn_more_behavior_title_textview);
         TextView descriptionTextView = (TextView) v
                 .findViewById(R.id.learn_more_description_textview);
+
+        View separator = v.findViewById(R.id.learn_more_separator);
+        TextView moreInfo = (TextView) v.findViewById(R.id.learn_more_more_info_textview);
+
         TextView addLabelTextView = (TextView) v.findViewById(R.id.learn_more_add_label);
         mProgressBar = (ProgressBar) v.findViewById(R.id.learn_more_progressbar);
         mProgressBar.setVisibility(View.GONE);
@@ -151,6 +155,11 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             titleTextView.setText(mAction.getTitle());
             descriptionTextView.setText(mAction.getDescription());
             addLabelTextView.setText(getText(R.string.action_i_want_this_label));
+            if(!mAction.getMoreInfo().isEmpty()) {
+                separator.setVisibility(View.VISIBLE);
+                moreInfo.setText(mAction.getMoreInfo());
+                moreInfo.setVisibility(View.VISIBLE);
+            }
         } else if (mGoal != null) {
             // this is a learn more screen for a Goal
             titleTextView.setText(mGoal.getTitle());
@@ -160,8 +169,13 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
         } else {
             // this is a learn more screen for a Behavior
             titleTextView.setText(mBehavior.getTitle());
-            descriptionTextView.setText(mBehavior.getMoreInfo());
+            descriptionTextView.setText((mBehavior.getDescription()));
             addLabelTextView.setText(getText(R.string.behavior_add_to_priorities_label));
+            if(!mBehavior.getMoreInfo().isEmpty()) {
+                separator.setVisibility(View.VISIBLE);
+                moreInfo.setText(mBehavior.getMoreInfo());
+                moreInfo.setVisibility(View.VISIBLE);
+            }
         }
         return v;
     }

--- a/src/main/java/org/tndata/android/compass/model/Action.java
+++ b/src/main/java/org/tndata/android/compass/model/Action.java
@@ -9,6 +9,7 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     private int behavior_id = -1;
     private int sequence_order = -1;
     private String more_info = "";
+    private String html_more_info = "";
     private String external_resource = "";
     private String notification_text = "";
     private String icon_url = "";
@@ -18,10 +19,10 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     }
 
     public Action(int id, int order, String title, String titleSlug,
-                  String description, int sequenceOrder, String moreInfo,
-                  String externalResource, String notificationText, String iconUrl,
+                  String description, String html_description, int sequenceOrder, String moreInfo,
+                  String htmlMoreInfo, String externalResource, String notificationText, String iconUrl,
                   String imageUrl, int behaviorId) {
-        super(id, title, titleSlug, description);
+        super(id, title, titleSlug, description, html_description);
         this.sequence_order = sequenceOrder;
         this.more_info = moreInfo;
         this.external_resource = externalResource;
@@ -29,16 +30,18 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
         this.icon_url = iconUrl;
         this.image_url = imageUrl;
         this.behavior_id = behaviorId;
+        this.html_more_info = htmlMoreInfo;
     }
 
     public Action(int id, int order, String title, String titleSlug,
-                  String description, Behavior behavior, int sequenceOrder,
-                  String moreInfo, String externalResource,
+                  String description, String html_description, Behavior behavior, int sequenceOrder,
+                  String moreInfo, String htmlMoreInfo, String externalResource,
                   String notificationText, String iconUrl, String imageUrl, int behaviorId) {
-        super(id, title, titleSlug, description);
+        super(id, title, titleSlug, description, html_description);
         this.behavior = behavior;
         this.sequence_order = sequenceOrder;
         this.more_info = moreInfo;
+        this.html_more_info = htmlMoreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -69,6 +72,10 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     public void setMoreInfo(String more_info    ) {
         this.more_info = more_info;
     }
+
+    public String getHTMLMoreInfo() { return html_more_info;}
+
+    public void setHTMLMoreInfo(String htmlMoreInfo) { this.html_more_info = htmlMoreInfo; }
 
     public String getExternalResource() {
         return external_resource;

--- a/src/main/java/org/tndata/android/compass/model/Behavior.java
+++ b/src/main/java/org/tndata/android/compass/model/Behavior.java
@@ -8,6 +8,7 @@ public class Behavior extends TDCBase implements Serializable,
 
     private static final long serialVersionUID = 7747989797893422842L;
     private String more_info = "";
+    private String html_more_info = "";
     private String external_resource = "";
     private String notification_text = "";
     private String icon_url = "";
@@ -19,10 +20,11 @@ public class Behavior extends TDCBase implements Serializable,
     }
 
     public Behavior(int id, int order, String title, String titleSlug,
-                    String description, String moreInfo, String externalResource,
-                    String notificationText, String iconUrl, String imageUrl) {
-        super(id, title, titleSlug, description);
+                    String description, String html_description, String moreInfo, String htmlMoreInfo,
+                    String externalResource, String notificationText, String iconUrl, String imageUrl) {
+        super(id, title, titleSlug, description, html_description);
         this.more_info = moreInfo;
+        this.html_more_info = htmlMoreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -30,11 +32,12 @@ public class Behavior extends TDCBase implements Serializable,
     }
 
     public Behavior(int id, int order, String title, String titleSlug,
-                    String description, String moreInfo, String externalResource,
-                    String notificationText, String iconUrl, String imageUrl,
+                    String description, String html_description, String moreInfo, String htmlMoreInfo,
+                    String externalResource, String notificationText, String iconUrl, String imageUrl,
                     ArrayList<Goal> goals) {
-        super(id, title, titleSlug, description);
+        super(id, title, titleSlug, description, html_description);
         this.more_info = moreInfo;
+        this.html_more_info = htmlMoreInfo;
         this.external_resource = externalResource;
         this.notification_text = notificationText;
         this.icon_url = iconUrl;
@@ -46,9 +49,13 @@ public class Behavior extends TDCBase implements Serializable,
         return more_info;
     }
 
+    public String getHTMLMoreInfo() { return html_more_info; }
+
     public void setMoreInfo(String more_info) {
         this.more_info = more_info;
     }
+
+    public void setHTMLMoreInfo(String html_more_info) { this.html_more_info = html_more_info; }
 
     public String getExternalResource() {
         return external_resource;

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -20,8 +20,8 @@ public class Category extends TDCBase implements Serializable,
     }
 
     public Category(int id, int order, String title, String titleSlug,
-                    String description, String iconUrl, String imageUrl) {
-        super(id, title, titleSlug, description);
+                    String description, String html_description, String iconUrl, String imageUrl) {
+        super(id, title, titleSlug, description, html_description);
         this.order = order;
         this.icon_url = iconUrl;
         this.image_url = imageUrl;
@@ -29,8 +29,8 @@ public class Category extends TDCBase implements Serializable,
     }
 
     public Category(int id, int order, String title, String titleSlug,
-                    String description, String iconUrl, String imageUrl, ArrayList<Goal> goals) {
-        super(id, title, titleSlug, description);
+                    String description, String html_description, String iconUrl, String imageUrl, ArrayList<Goal> goals) {
+        super(id, title, titleSlug, description, html_description);
         this.order = order;
         this.icon_url = iconUrl;
         this.image_url = imageUrl;
@@ -38,8 +38,8 @@ public class Category extends TDCBase implements Serializable,
     }
 
     public Category(int id, int order, String title, String titleSlug,
-                    String description, String iconUrl, String imageUrl, String color) {
-        super(id, title, titleSlug, description);
+                    String description, String html_description, String iconUrl, String imageUrl, String color) {
+        super(id, title, titleSlug, description, html_description);
         this.order = order;
         this.icon_url = iconUrl;
         this.image_url = imageUrl;

--- a/src/main/java/org/tndata/android/compass/model/Goal.java
+++ b/src/main/java/org/tndata/android/compass/model/Goal.java
@@ -18,8 +18,8 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
     }
 
     public Goal(int id, int order, String title, String titleSlug,
-                String description, String subtitle, String outcome, String iconUrl) {
-        super(id, title, titleSlug, description);
+                String description, String html_description, String subtitle, String outcome, String iconUrl) {
+        super(id, title, titleSlug, description, html_description);
         this.subtitle = subtitle;
         this.outcome = outcome;
         this.icon_url = iconUrl;
@@ -27,9 +27,9 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
     }
 
     public Goal(int id, int order, String title, String titleSlug,
-                String description, String subtitle, String outcome,
+                String description, String html_description, String subtitle, String outcome,
                 String iconUrl, ArrayList<Category> categories) {
-        super(id, title, titleSlug, description);
+        super(id, title, titleSlug, description, html_description);
         this.subtitle = subtitle;
         this.outcome = outcome;
         this.icon_url = iconUrl;

--- a/src/main/java/org/tndata/android/compass/model/TDCBase.java
+++ b/src/main/java/org/tndata/android/compass/model/TDCBase.java
@@ -9,16 +9,18 @@ public class TDCBase implements Serializable {
     private String title = "";
     private String title_slug = "";
     private String description = "";
+    private String html_description = "";
     private int mappingId = -1;
 
     public TDCBase() {
     }
 
-    public TDCBase(int id, String name, String nameSlug, String description) {
+    public TDCBase(int id, String name, String nameSlug, String description, String html_description) {
         this.setId(id);
         this.setTitle(name);
         this.setTitleSlug(nameSlug);
         this.setDescription(description);
+        this.setHTMLDescription(html_description);
     }
 
     public int getId() {
@@ -37,6 +39,8 @@ public class TDCBase implements Serializable {
         return this.description;
     }
 
+    public String getHTMLDescription() { return this.html_description; }
+
     public void setId(int id) {
         this.id = id;
     }
@@ -52,6 +56,8 @@ public class TDCBase implements Serializable {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    public void setHTMLDescription(String html_description) { this.html_description = html_description; }
 
     public int getMappingId() {
         return mappingId;

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -56,7 +56,6 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
             return null;
         }
         String result = "";
-        String actionResponse = "";
         try {
 
             BufferedReader bReader = new BufferedReader(new InputStreamReader(
@@ -68,8 +67,6 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
             }
             bReader.close();
 
-            // TODO: Why do we do this first? It seems to strip the html from within our JSON strings
-            //actionResponse = Html.fromHtml(result).toString();
             JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Action> actions = new ArrayList<Action>();

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
-import android.text.Html;
 import android.util.Log;
 
 import com.google.gson.FieldNamingPolicy;
@@ -69,9 +68,9 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
             }
             bReader.close();
 
-            actionResponse = Html.fromHtml(result).toString();
-
-            JSONObject response = new JSONObject(actionResponse);
+            // TODO: Why do we do this first? It seems to strip the html from within our JSON strings
+            //actionResponse = Html.fromHtml(result).toString();
+            JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Action> actions = new ArrayList<Action>();
             for (int i = 0; i < jArray.length(); i++) {

--- a/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
-import android.text.Html;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -57,7 +56,6 @@ public class GetUserBehaviorsTask extends AsyncTask<String, Void, ArrayList<Beha
             return null;
         }
         String result = "";
-        String behaviorResponse = "";
         try {
 
             BufferedReader bReader = new BufferedReader(new InputStreamReader(
@@ -69,9 +67,7 @@ public class GetUserBehaviorsTask extends AsyncTask<String, Void, ArrayList<Beha
             }
             bReader.close();
 
-            behaviorResponse = Html.fromHtml(result).toString();
-
-            JSONObject response = new JSONObject(behaviorResponse);
+            JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Behavior> behaviors = new ArrayList<Behavior>();
             for (int i = 0; i < jArray.length(); i++) {

--- a/src/main/java/org/tndata/android/compass/task/GetUserCategoriesTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserCategoriesTask.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
-import android.text.Html;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -48,7 +47,6 @@ public class GetUserCategoriesTask extends
             return null;
         }
         String result = "";
-        String createResponse = "";
         try {
 
             BufferedReader bReader = new BufferedReader(new InputStreamReader(
@@ -60,9 +58,7 @@ public class GetUserCategoriesTask extends
             }
             bReader.close();
 
-            createResponse = Html.fromHtml(result).toString();
-
-            JSONObject response = new JSONObject(createResponse);
+            JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Category> categories = new ArrayList<Category>();
             for (int i = 0; i < jArray.length(); i++) {

--- a/src/main/java/org/tndata/android/compass/task/GetUserGoalsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserGoalsTask.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
-import android.text.Html;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -48,7 +47,6 @@ public class GetUserGoalsTask extends AsyncTask<String, Void, ArrayList<Goal>> {
             return null;
         }
         String result = "";
-        String createResponse = "";
         try {
 
             BufferedReader bReader = new BufferedReader(new InputStreamReader(
@@ -60,9 +58,7 @@ public class GetUserGoalsTask extends AsyncTask<String, Void, ArrayList<Goal>> {
             }
             bReader.close();
 
-            createResponse = Html.fromHtml(result).toString();
-
-            JSONObject response = new JSONObject(createResponse);
+            JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Goal> goals = new ArrayList<Goal>();
             for (int i = 0; i < jArray.length(); i++) {

--- a/src/main/java/org/tndata/android/compass/task/GetUserProfileTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserProfileTask.java
@@ -1,7 +1,6 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
-import android.text.Html;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -43,7 +42,6 @@ public class GetUserProfileTask extends AsyncTask<String, Void, ArrayList<Survey
             return null;
         }
         String result = "";
-        String profileResponse = "";
         try {
 
             BufferedReader bReader = new BufferedReader(new InputStreamReader(
@@ -55,9 +53,7 @@ public class GetUserProfileTask extends AsyncTask<String, Void, ArrayList<Survey
             }
             bReader.close();
 
-            profileResponse = Html.fromHtml(result).toString();
-
-            JSONObject response = new JSONObject(profileResponse);
+            JSONObject response = new JSONObject(result);
             ArrayList<Survey> surveys = new ArrayList<Survey>();
             JSONArray jArray = response.getJSONArray("results").getJSONObject(0).getJSONArray
                     ("bio");

--- a/src/main/res/layout/fragment_learn_more.xml
+++ b/src/main/res/layout/fragment_learn_more.xml
@@ -60,5 +60,26 @@
             android:layout_below="@id/learn_more_add_label"
             android:layout_marginTop="40dp"
             android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+        <View
+            android:id="@+id/learn_more_separator"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@id/learn_more_description_textview"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="10dp"
+            android:background="@color/disabled_text_color"
+            android:visibility="gone"/>
+
+        <TextView
+            android:id="@+id/learn_more_more_info_textview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/learn_more_separator"
+            android:layout_marginTop="10dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:visibility="gone" />
+
+
     </RelativeLayout>
 </ScrollView>


### PR DESCRIPTION
This PR includes `html_more_info` attributes for Behaviors and Actions and `html_description` attributes for Behaviors, Actions, Categories, and Goals. Both of these fields are the parsed version of the markdown that is stored in the `more_info` and `description` attributes, respectively. However, we don't yet display the HTML content, though, due to the fact that `Html.fromHtml` ignores a lot of tags, including `<ul>`s.

This PR also includes the following changes:

* Behavior/Action's `more_info` content is displayed in the `LearnMoreFragment`
* in the `GoalDetailsFragment`, selected actions are only listed once (this was bug)
* in the `GoalDetailsFragment` we don't reload data from the API every single time the fragment is loaded.
* The `GetUser____Task` tasks no longer use `Html.fromHtml` to parse the JSON results.