### PR TITLE
UI updates for "Learn More" and a few fixes for Triggers

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
@@ -87,22 +87,21 @@ public class BaseTriggerActivity extends ActionBarActivity implements
 
     @Override
     public void onDialogTimeSet(int reference, int hourOfDay, int minute) {
-        mTime = String.format("%02d", hourOfDay) + ":" + String.format("%02d", minute);
+        mTime = R.string.time_picker_confirmation_toast +
+                String.format("%02d", hourOfDay) + ":" +
+                String.format("%02d", minute);
         Toast.makeText(this, mTime, Toast.LENGTH_SHORT).show();
         showRecurrencePicker();
     }
 
     private void saveTrigger() {
         if (!TextUtils.isEmpty(mRrule)) {
-
             if (mActionToUpdate != null) {
                 new AddActionTriggerTask(((CompassApplication) getApplication()).getToken(),
                         mRrule, mTime, String.valueOf(mActionToUpdate.getMappingId()))
                         .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-            } else if (mBehaviorToUpdate != null) {
-                // TODO save any behavior mapping here
-                Toast.makeText(this, mTime + " " + mRrule, Toast.LENGTH_LONG).show();
             }
+            Toast.makeText(this, R.string.recurrence_picker_confirmation_toast, Toast.LENGTH_SHORT).show();
         }
     }
 }

--- a/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
@@ -6,6 +6,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v7.app.ActionBarActivity;
 import android.text.TextUtils;
 import android.text.format.Time;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.doomonafireball.betterpickers.recurrencepicker.EventRecurrence;
@@ -24,7 +25,8 @@ import org.tndata.android.compass.task.AddActionTriggerTask;
  */
 public class BaseTriggerActivity extends ActionBarActivity implements
         RecurrencePickerDialog.OnRecurrenceSetListener,
-        TimePickerDialogFragment.TimePickerDialogHandler {
+        TimePickerDialogFragment.TimePickerDialogHandler,
+        AddActionTriggerTask.AddActionTriggerTaskListener {
 
     private EventRecurrence mEventRecurrence = new EventRecurrence();
     private String mRrule;
@@ -33,7 +35,26 @@ public class BaseTriggerActivity extends ActionBarActivity implements
     private Action mActionToUpdate;
     private Behavior mBehaviorToUpdate;
 
+    private static final String TAG = "BaseTriggerActivity";
     private static final String FRAG_TAG_RECUR_PICKER = "recurrencePickerDialogFragment";
+
+    /*
+    Ensure that our RRULE string is formatted property. For the API to accept
+    it, it must start with an 'RRULE:' prefix.
+     */
+    public void setRRULE(String rrule) {
+        if(!rrule.isEmpty() && !rrule.toUpperCase().startsWith("RRULE:")) {
+            rrule = "RRULE:" + rrule;
+        }
+        mRrule = rrule;
+    }
+
+    public String getRRULE() {
+        if(!mRrule.isEmpty() && !mRrule.toUpperCase().startsWith("RRULE:")) {
+            mRrule = "RRULE:" + mRrule.toUpperCase();
+        }
+        return mRrule;
+    }
 
     protected void getRecurrenceSchedule(Action action, Behavior behavior) {
         if (action != null) {
@@ -49,7 +70,7 @@ public class BaseTriggerActivity extends ActionBarActivity implements
     private void showTimePicker() {
         TimePickerBuilder tpb = new TimePickerBuilder()
                 .setFragmentManager(getSupportFragmentManager())
-                .setStyleResId(R.style.BetterPickersDialogFragment);
+                .setStyleResId(R.style.BetterPickersDialogFragment_Light);
         tpb.show();
     }
 
@@ -78,30 +99,53 @@ public class BaseTriggerActivity extends ActionBarActivity implements
 
     @Override
     public void onRecurrenceSet(String rrule) {
-        mRrule = rrule;
-        if (mRrule != null) {
-            mEventRecurrence.parse(mRrule);
+        // Our API needs the 'RRULE' prefix on the rrule string, but
+        // BetterPicker's EventRecurrence should *not* have that: https://goo.gl/QhY9aC
+        setRRULE(rrule);
+        if (rrule != null) {
+            // use local rrule string for the EventRecurrence
+            mEventRecurrence.parse(rrule);
         }
         saveTrigger();
     }
 
     @Override
     public void onDialogTimeSet(int reference, int hourOfDay, int minute) {
-        mTime = R.string.time_picker_confirmation_toast +
-                String.format("%02d", hourOfDay) + ":" +
+        Log.d(TAG, "reference: " + reference + ", hourOfDay: " + hourOfDay + ", minute: " + minute);
+        mTime = String.format("%02d", hourOfDay) + ":" +
                 String.format("%02d", minute);
-        Toast.makeText(this, mTime, Toast.LENGTH_SHORT).show();
+        Toast.makeText(this,
+                getText(R.string.time_picker_confirmation_toast) + mTime,
+                Toast.LENGTH_SHORT).show();
         showRecurrencePicker();
     }
 
     private void saveTrigger() {
-        if (!TextUtils.isEmpty(mRrule)) {
+        String rrule = getRRULE();
+        Log.d(TAG, "mTime: " + mTime);
+        Log.d(TAG, "mRrule: " + rrule);
+
+        if (!TextUtils.isEmpty(rrule)) {
             if (mActionToUpdate != null) {
-                new AddActionTriggerTask(((CompassApplication) getApplication()).getToken(),
-                        mRrule, mTime, String.valueOf(mActionToUpdate.getMappingId()))
+                new AddActionTriggerTask(this,
+                        ((CompassApplication) getApplication()).getToken(),
+                        rrule, mTime, String.valueOf(mActionToUpdate.getMappingId()))
                         .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             }
-            Toast.makeText(this, R.string.recurrence_picker_confirmation_toast, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    public void actionTriggerAdded(Action action) {
+        // action is the updated Action, presumably with a Trigger attached.
+        if(action != null) {
+            mActionToUpdate = action;
+
+            Log.d(TAG, "Updated Action & Trigger: " + action.getCustomTrigger().getRecurrences());
+            Toast.makeText(this,
+                    getText(R.string.recurrence_picker_confirmation_toast),
+                    Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, "Failed to save Reminder", Toast.LENGTH_SHORT).show();
         }
     }
 }

--- a/src/main/java/org/tndata/android/compass/activity/BehaviorActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BehaviorActivity.java
@@ -1,6 +1,12 @@
 package org.tndata.android.compass.activity;
 
-import java.util.ArrayList;
+import android.app.Fragment;
+import android.graphics.Color;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
+import android.view.KeyEvent;
+import android.view.MenuItem;
 
 import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.R;
@@ -16,14 +22,7 @@ import org.tndata.android.compass.task.AddBehaviorTask;
 import org.tndata.android.compass.task.DeleteBehaviorTask;
 import org.tndata.android.compass.util.Constants;
 
-import android.app.Fragment;
-import android.graphics.Color;
-import android.os.AsyncTask;
-import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
-import android.support.v7.widget.Toolbar;;
-import android.view.KeyEvent;
-import android.view.MenuItem;
+import java.util.ArrayList;
 
 
 public class BehaviorActivity extends BaseTriggerActivity implements

--- a/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
@@ -1,19 +1,5 @@
 package org.tndata.android.compass.fragment;
 
-import java.util.ArrayList;
-
-import org.tndata.android.compass.CompassApplication;
-import org.tndata.android.compass.R;
-import org.tndata.android.compass.model.Action;
-import org.tndata.android.compass.model.Behavior;
-import org.tndata.android.compass.model.Category;
-import org.tndata.android.compass.model.Goal;
-import org.tndata.android.compass.task.ActionLoaderTask;
-import org.tndata.android.compass.task.ActionLoaderTask.ActionLoaderListener;
-import org.tndata.android.compass.ui.ActionCellView;
-import org.tndata.android.compass.util.ImageCache;
-import org.tndata.android.compass.util.ImageHelper;
-
 import android.app.Activity;
 import android.app.Fragment;
 import android.os.AsyncTask;
@@ -30,6 +16,20 @@ import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.R;
+import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.task.ActionLoaderTask;
+import org.tndata.android.compass.task.ActionLoaderTask.ActionLoaderListener;
+import org.tndata.android.compass.ui.ActionCellView;
+import org.tndata.android.compass.util.ImageCache;
+import org.tndata.android.compass.util.ImageHelper;
+
+import java.util.ArrayList;
 
 public class BehaviorFragment extends Fragment implements ActionLoaderListener, ActionCellView
         .ActionViewListener {
@@ -215,17 +215,14 @@ public class BehaviorFragment extends Fragment implements ActionLoaderListener, 
         PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
         //Inflating the Popup using xml file
         popup.getMenuInflater()
-                .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
+                .inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
-                    case R.id.menu_popup_remove_item:
+                    case R.id.menu_behavior_popup_remove_item:
                         mCallback.deleteBehavior(mBehavior);
-                        break;
-                    case R.id.menu_popup_edit_item:
-                        mCallback.fireBehaviorPicker(mBehavior);
                         break;
                 }
                 return true;

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -2,10 +2,8 @@ package org.tndata.android.compass.fragment;
 
 import android.app.Activity;
 import android.app.Fragment;
-import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -115,6 +113,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 .findViewById(R.id.learn_more_description_textview);
 
         View separator = v.findViewById(R.id.learn_more_separator);
+        TextView moreInfoHeader = (TextView) v.findViewById(R.id.learn_more_more_info_header_textview);
         TextView moreInfo = (TextView) v.findViewById(R.id.learn_more_more_info_textview);
 
         TextView addLabelTextView = (TextView) v.findViewById(R.id.learn_more_add_label);
@@ -162,6 +161,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 separator.setVisibility(View.VISIBLE);
                 moreInfo.setText(mAction.getMoreInfo());
                 moreInfo.setVisibility(View.VISIBLE);
+                moreInfoHeader.setVisibility(View.VISIBLE);
             }
         } else if (mGoal != null) {
             // this is a learn more screen for a Goal
@@ -178,6 +178,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 separator.setVisibility(View.VISIBLE);
                 moreInfo.setText(mBehavior.getMoreInfo());
                 moreInfo.setVisibility(View.VISIBLE);
+                moreInfoHeader.setVisibility(View.VISIBLE);
             }
         }
         return v;

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -237,17 +237,20 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
     }
 
     private void showPopup() {
-        //Creating the instance of PopupMenu
         PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
-        //Inflating the Popup using xml file
-        popup.getMenuInflater()
-                .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
+        // Inflating the correct menu depending on which kind of content we're viewing.
+        if(mAction != null) {
+            popup.getMenuInflater()
+                    .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
+        }else {
+            popup.getMenuInflater().inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
+        }
 
-        //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_remove_item:
+                    case R.id.menu_behavior_popup_remove_item:
                         if (mAction != null) {
                             new DeleteActionTask(getActivity(), LearnMoreFragment.this, String
                                     .valueOf(mAction.getMappingId()))
@@ -267,8 +270,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                 return true;
             }
         });
-
-        popup.show(); //showing popup menu
+        popup.show();
     }
 
     public void actionChanged(Action action) {

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -156,6 +156,9 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             // this is a learn more screen for an Action
             titleTextView.setText(mAction.getTitle());
             descriptionTextView.setText(mAction.getDescription());
+
+            // Display different content in the "Add this" label when the user
+            // has already selected the item.
             if(mAction.getCustomTrigger() != null) {
                 addLabelTextView.setText(
                         mAction.getCustomTrigger().getRecurrencesDisplay() + " at " +
@@ -181,7 +184,14 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             // this is a learn more screen for a Behavior
             titleTextView.setText(mBehavior.getTitle());
             descriptionTextView.setText((mBehavior.getDescription()));
-            addLabelTextView.setText(getText(R.string.behavior_add_to_priorities_label));
+
+            // Display different content in the "Add this" label when the user
+            // has already selected the item.
+            if(mBehavior.getMappingId() > 0) {
+                addLabelTextView.setText(getText(R.string.behavior_management_label));
+            } else {
+                addLabelTextView.setText(getText(R.string.behavior_add_to_priorities_label));
+            }
             if (!mBehavior.getMoreInfo().isEmpty()) {
                 separator.setVisibility(View.VISIBLE);
                 moreInfo.setText(mBehavior.getMoreInfo());

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -156,7 +156,15 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             // this is a learn more screen for an Action
             titleTextView.setText(mAction.getTitle());
             descriptionTextView.setText(mAction.getDescription());
-            addLabelTextView.setText(getText(R.string.action_i_want_this_label));
+            if(mAction.getCustomTrigger() != null) {
+                addLabelTextView.setText(
+                        mAction.getCustomTrigger().getRecurrencesDisplay() + " at " +
+                                mAction.getCustomTrigger().getTime());
+            } else if(mAction.getMappingId() > 0) {
+                addLabelTextView.setText(getText(R.string.action_management_label));
+            } else {
+                addLabelTextView.setText(getText(R.string.action_i_want_this_label));
+            }
             if (!mAction.getMoreInfo().isEmpty()) {
                 separator.setVisibility(View.VISIBLE);
                 moreInfo.setText(mAction.getMoreInfo());

--- a/src/main/java/org/tndata/android/compass/model/Action.java
+++ b/src/main/java/org/tndata/android/compass/model/Action.java
@@ -14,6 +14,7 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
     private String notification_text = "";
     private String icon_url = "";
     private String image_url = "";
+    private Trigger custom_trigger;
 
     public Action() {
     }
@@ -115,6 +116,14 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
 
     public void setBehavior_id(int behavior_id) {
         this.behavior_id = behavior_id;
+    }
+
+    public Trigger getCustomTrigger() {
+        return custom_trigger;
+    }
+
+    public void setCustomTrigger(Trigger trigger) {
+        this.custom_trigger = trigger;
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/model/Trigger.java
+++ b/src/main/java/org/tndata/android/compass/model/Trigger.java
@@ -1,0 +1,108 @@
+package org.tndata.android.compass.model;
+
+import java.io.Serializable;
+
+public class Trigger implements Serializable, Comparable<Trigger> {
+
+    private static final long serialVersionUID = 7914473023695112323L;
+    private int id = -1;
+    private String recurrences_display = "";
+    private String recurrences = ""; // utf RFC2445 string
+    private String time = "";
+    private String name = "";
+    private String name_slug = "";
+    private String location = "";
+
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getRecurrencesDisplay() {
+        return recurrences_display;
+    }
+
+    public void setRecurrencesDisplay(String recurrences_display) {
+        this.recurrences_display = recurrences_display;
+    }
+
+    public String getRecurrences() {
+        return recurrences;
+    }
+
+    public void setRecurrences(String recurrences) {
+        this.recurrences = recurrences;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNameSlug() {
+        return name_slug;
+    }
+
+    public void setNameSlug(String name_slug) {
+        this.name_slug = name_slug;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        boolean result = false;
+        if (object == null) {
+            result = false;
+        } else if (object == this) {
+            result = true;
+        } else if (object instanceof Action) {
+            if (this.getId() == ((Action) object).getId()) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 7 * hash + this.getName().hashCode();
+        return hash;
+    }
+
+    @Override
+    public int compareTo(Trigger another) {
+        if (getId() == another.getId()) {
+            return 0;
+        } else if (getId() < another.getId()) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -10,6 +10,7 @@ import com.google.gson.GsonBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Trigger;
 import org.tndata.android.compass.util.Constants;
 import org.tndata.android.compass.util.NetworkHelper;
 
@@ -70,12 +71,26 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
             JSONObject response = new JSONObject(result);
             JSONArray jArray = response.getJSONArray("results");
             ArrayList<Action> actions = new ArrayList<Action>();
+
             for (int i = 0; i < jArray.length(); i++) {
                 JSONObject userAction = jArray.getJSONObject(i);
-                Log.d("USER ACTION", userAction.toString(2));
+                //Log.d("USER ACTION", userAction.toString(2));
                 Action action = gson.fromJson(userAction.getString("action"), Action.class);
                 action.setMappingId(userAction.getInt("id"));
                 actions.add(action);
+
+                Log.d("UserAction", "Created UserAction ("+
+                        action.getMappingId() + ") with Action (" +
+                        action.getId() + ")");
+
+                Log.d("Trigger JSON", userAction.getString("custom_trigger"));
+
+                if(!userAction.isNull("custom_trigger")) {
+                    action.setCustomTrigger(
+                            gson.fromJson(userAction.getString("custom_trigger"), Trigger.class));
+
+                    Log.d("TRIGGER", "loaded trigger: " + action.getCustomTrigger().getName());
+                }
             }
             return actions;
 

--- a/src/main/res/layout/fragment_learn_more.xml
+++ b/src/main/res/layout/fragment_learn_more.xml
@@ -72,10 +72,20 @@
             android:visibility="gone"/>
 
         <TextView
-            android:id="@+id/learn_more_more_info_textview"
+            android:id="@+id/learn_more_more_info_header_textview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@id/learn_more_separator"
+            android:layout_marginTop="10dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:visibility="gone"
+            android:text="@string/more_info_header"/>
+
+        <TextView
+            android:id="@+id/learn_more_more_info_textview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/learn_more_more_info_header_textview"
             android:layout_marginTop="10dp"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:visibility="gone" />

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="category_goals_add">What are your %1$s goals?</string>
 
     <!-- LearnMoreFragment -->
+    <string name="behavior_management_label">Manage your Priority</string>
     <string name="action_management_label">Set a Reminder for your Action</string>
     <string name="more_info_header">More Information</string>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="category_goals">%1$s goals</string>
     <string name="category_goals_add">What are your %1$s goals?</string>
 
+    <!-- LearnMoreFragment -->
+    <string name="more_info_header">More Information</string>
+
     <!-- GoalDetailsActivity -->
     <string name="goal_title_label">Achieve Your Goal</string>
     <string name="goal_management">Achieve your Goal</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -14,6 +14,10 @@
     <string name="nav_drawer_action">Compass</string>
     <string name="main_tab_title">My Journey</string>
 
+    <!-- Time/Recurrence pickers -->
+    <string name="time_picker_confirmation_toast">You have selected </string>
+    <string name="recurrence_picker_confirmation_toast">Reminder Saved!</string>
+
     <!-- LoginActivity -->
     <string name="terms_title">Terms and Conditions</string>
     <string name="launcher_sign_up">SIGN UP</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="category_goals_add">What are your %1$s goals?</string>
 
     <!-- LearnMoreFragment -->
+    <string name="action_management_label">Set a Reminder for your Action</string>
     <string name="more_info_header">More Information</string>
 
     <!-- GoalDetailsActivity -->


### PR DESCRIPTION
This PR adds:

- A header above the _More Info_ text in the `LearnMoreFragment`
- end-user-friendly messages in the `Toast` messages after setting a reminder
- a light-themed time picker
- a fix for the format of the `RRULE` string; our api requires an `RRULE:` prefix on the recurrence information
- an `AddActionTriggerTaskListener` interface to `AddActionTriggerTask`, so there's a callback method that can be called after a user updates a custom trigger for an Action.