### PR TITLE
Revise the interaction on the Goal Cards

### DIFF
--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -44,6 +44,10 @@ public class CompassApplication extends Application {
         mCategories = categories;
     }
 
+    public void removeCategory(Category category) {
+        mCategories.remove(category);
+    }
+    
     public ArrayList<Goal> getGoals() {
         return mGoals;
     }
@@ -52,8 +56,16 @@ public class CompassApplication extends Application {
         mGoals = goals;
     }
 
+    public void removeGoal(Goal goal) {
+        mGoals.remove(goal);
+    }
+
     public ArrayList<Action> getActions() {
         return mActions;
+    }
+
+    public void removeAction(Action action) {
+        mActions.remove(action);
     }
 
     public void setActions(ArrayList<Action> actions) {

--- a/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalDetailsActivity.java
@@ -124,10 +124,7 @@ public class GoalDetailsActivity extends BaseTriggerActivity implements
         new DeleteGoalTask(this, this, goals).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 
         // Delete the goal from the Compass Application (will affect the UI)
-        ArrayList<Goal> applicationGoals = ((CompassApplication) getApplication()).getGoals();
-        applicationGoals.remove(goal);
-        ((CompassApplication) getApplication()).setGoals(applicationGoals);
-
+        ((CompassApplication) getApplication()).removeGoal(goal);
         setResult(Constants.GOALS_CHANGED_RESULT_CODE);
     }
 

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -55,7 +55,7 @@ public class CategoryFragmentAdapter extends
             menuImageView = (ImageView) view.findViewById(R.id.goal_popup_imageview);
 
             moreInfoTextView = (TextView) view.findViewById(R.id
-                    .list_item_category_goal_more_info_button);
+                    .list_item_category_goal_more_info_textview);
         }
 
         public void setCircleViewBackgroundColor(String colorString) {
@@ -89,7 +89,6 @@ public class CategoryFragmentAdapter extends
     private Category mCategory;
     private List<Goal> mItems;
     private CategoryFragmentAdapterInterface mCallback;
-    private static final String TAG = "CategoryFragmentAdapter";
 
     public CategoryFragmentAdapter(Context context, List<Goal> objects, Category category,
                                    CategoryFragmentAdapterInterface callback) {
@@ -164,9 +163,7 @@ public class CategoryFragmentAdapter extends
         return new CategoryGoalViewHolder(itemView);
     }
 
-    public void showPopup(View anchor, Goal goal) {
-
-        final Goal localGoal = goal;
+    public void showPopup(final View anchor, final Goal goal) {
 
         CompassPopupMenu popup = CompassPopupMenu.newInstance(mContext, anchor);
         popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
@@ -174,13 +171,13 @@ public class CategoryFragmentAdapter extends
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_add_behavior:
-                        mCallback.chooseBehaviors(localGoal);
+                        mCallback.chooseBehaviors(goal);
                         break;
                     case R.id.menu_popup_view_details:
-                        mCallback.viewGoal(localGoal);
+                        mCallback.viewGoal(goal);
                         break;
                     case R.id.menu_popup_remove_goal:
-                        mCallback.deleteGoal(localGoal);
+                        mCallback.deleteGoal(goal);
                         break;
                 }
                 return true;

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -38,7 +38,7 @@ public class CategoryFragmentAdapter extends
         LinearLayout goalContainer;
         ImageView iconImageView;
         ImageView menuImageView;
-        TextView moreInfoButton;
+        TextView moreInfoTextView;
 
         public CategoryGoalViewHolder(View view) {
             super(view);
@@ -54,7 +54,7 @@ public class CategoryFragmentAdapter extends
                     .list_item_category_goal_icon_imageview);
             menuImageView = (ImageView) view.findViewById(R.id.goal_popup_imageview);
 
-            moreInfoButton = (TextView) view.findViewById(R.id
+            moreInfoTextView = (TextView) view.findViewById(R.id
                     .list_item_category_goal_more_info_button);
         }
 
@@ -75,11 +75,11 @@ public class CategoryFragmentAdapter extends
             if(descriptionTextView.getVisibility() == View.GONE) {
                 circleView.setVisibility(View.GONE);
                 descriptionTextView.setVisibility(View.VISIBLE);
-                moreInfoButton.setVisibility(View.VISIBLE);
+                moreInfoTextView.setVisibility(View.VISIBLE);
             }else {
                 circleView.setVisibility(View.VISIBLE);
                 descriptionTextView.setVisibility(View.GONE);
-                moreInfoButton.setVisibility(View.GONE);
+                moreInfoTextView.setVisibility(View.GONE);
             }
         }
 
@@ -125,7 +125,7 @@ public class CategoryFragmentAdapter extends
         ((CategoryGoalViewHolder) viewHolder).iconImageView.setImageResource(
                 goal.getProgressIcon());
 
-        ((CategoryGoalViewHolder) viewHolder).moreInfoButton.setOnClickListener(
+        ((CategoryGoalViewHolder) viewHolder).moreInfoTextView.setOnClickListener(
             new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -7,9 +7,9 @@ import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -18,14 +18,17 @@ import android.widget.TextView;
 import org.tndata.android.compass.R;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.ui.CompassPopupMenu;
 
 import java.util.List;
 
 public class CategoryFragmentAdapter extends
         RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
     public interface CategoryFragmentAdapterInterface {
         public void chooseBehaviors(Goal goal);
         public void viewGoal(Goal goal);
+        public void deleteGoal(Goal goal);
     }
 
     static class CategoryGoalViewHolder extends RecyclerView.ViewHolder {
@@ -34,7 +37,8 @@ public class CategoryFragmentAdapter extends
         RelativeLayout circleView;
         LinearLayout goalContainer;
         ImageView iconImageView;
-        Button moreInfoButton;
+        ImageView menuImageView;
+        TextView moreInfoButton;
 
         public CategoryGoalViewHolder(View view) {
             super(view);
@@ -48,8 +52,9 @@ public class CategoryFragmentAdapter extends
                     .list_item_category_goal_goal_container);
             iconImageView = (ImageView) view.findViewById(R.id
                     .list_item_category_goal_icon_imageview);
+            menuImageView = (ImageView) view.findViewById(R.id.goal_popup_imageview);
 
-            moreInfoButton = (Button) view.findViewById(R.id
+            moreInfoButton = (TextView) view.findViewById(R.id
                     .list_item_category_goal_more_info_button);
         }
 
@@ -84,6 +89,7 @@ public class CategoryFragmentAdapter extends
     private Category mCategory;
     private List<Goal> mItems;
     private CategoryFragmentAdapterInterface mCallback;
+    private static final String TAG = "CategoryFragmentAdapter";
 
     public CategoryFragmentAdapter(Context context, List<Goal> objects, Category category,
                                    CategoryFragmentAdapterInterface callback) {
@@ -128,6 +134,16 @@ public class CategoryFragmentAdapter extends
             }
         );
 
+        // Hook up the popup menu
+        ((CategoryGoalViewHolder) viewHolder).menuImageView.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        showPopup(v, goal);
+                    }
+                }
+        );
+
         // Expand/Collapse the card when tapped
         ((CategoryGoalViewHolder) viewHolder).itemView.setOnClickListener(
             new View.OnClickListener() {
@@ -146,6 +162,31 @@ public class CategoryFragmentAdapter extends
         LayoutInflater inflater = LayoutInflater.from(viewGroup.getContext());
         View itemView = inflater.inflate(R.layout.list_item_category_goal, viewGroup, false);
         return new CategoryGoalViewHolder(itemView);
+    }
+
+    public void showPopup(View anchor, Goal goal) {
+
+        final Goal localGoal = goal;
+
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(mContext, anchor);
+        popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
+            public boolean onMenuItemClick(MenuItem item) {
+                switch (item.getItemId()) {
+                    case R.id.menu_popup_add_behavior:
+                        mCallback.chooseBehaviors(localGoal);
+                        break;
+                    case R.id.menu_popup_view_details:
+                        mCallback.viewGoal(localGoal);
+                        break;
+                    case R.id.menu_popup_remove_goal:
+                        mCallback.deleteGoal(localGoal);
+                        break;
+                }
+                return true;
+            }
+        });
+        popup.show();
     }
 
 }

--- a/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
@@ -12,7 +12,6 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -26,6 +25,7 @@ import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.task.ActionLoaderTask;
 import org.tndata.android.compass.task.ActionLoaderTask.ActionLoaderListener;
 import org.tndata.android.compass.ui.ActionCellView;
+import org.tndata.android.compass.ui.CompassPopupMenu;
 import org.tndata.android.compass.util.ImageCache;
 import org.tndata.android.compass.util.ImageHelper;
 
@@ -212,13 +212,14 @@ public class BehaviorFragment extends Fragment implements ActionLoaderListener, 
 
     private void showPopup() {
         //Creating the instance of PopupMenu
-        PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(getActivity(), mAddImageView);
+
         //Inflating the Popup using xml file
         popup.getMenuInflater()
                 .inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_behavior_popup_remove_item:

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -245,8 +245,8 @@ public class CategoryFragment extends Fragment implements
         Log.d(TAG, "Deleting Goal: " + goal.getTitle());
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMessage("You are about to permanently remove this")
-                .setTitle("Delete Goal?")
+        builder.setMessage(getText(R.string.goal_dialog_delete_message))
+                .setTitle(getText(R.string.goal_dialog_delete_title))
                 .setNegativeButton(R.string.picker_cancel, new DialogInterface.OnClickListener(){
                     public void onClick(DialogInterface dialog, int id) {
                         dialog.dismiss();

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -10,7 +10,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -25,6 +24,7 @@ import org.tndata.android.compass.task.GetUserActionsTask;
 import org.tndata.android.compass.task.GetUserBehaviorsTask;
 import org.tndata.android.compass.ui.ActionCellView;
 import org.tndata.android.compass.ui.BehaviorListView;
+import org.tndata.android.compass.ui.CompassPopupMenu;
 import org.tndata.android.compass.util.ImageCache;
 
 import java.util.ArrayList;
@@ -227,9 +227,9 @@ public class GoalDetailsFragment extends Fragment implements
 
     private void showPopup() {
         //Creating the instance of PopupMenu
-        PopupMenu popup = new PopupMenu(getActivity(), mChooseMore);
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(getActivity(), mChooseMore);
         popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_add_behavior:

--- a/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/GoalDetailsFragment.java
@@ -5,7 +5,6 @@ import android.app.Fragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -24,7 +23,6 @@ import org.tndata.android.compass.task.GetUserActionsTask;
 import org.tndata.android.compass.task.GetUserBehaviorsTask;
 import org.tndata.android.compass.ui.ActionCellView;
 import org.tndata.android.compass.ui.BehaviorListView;
-import org.tndata.android.compass.ui.CompassPopupMenu;
 import org.tndata.android.compass.util.ImageCache;
 
 import java.util.ArrayList;
@@ -42,7 +40,6 @@ public class GoalDetailsFragment extends Fragment implements
     private LinearLayout mBehaviorActionsContainer;
     private ProgressBar mProgressBar;
     private GoalDetailsFragmentListener mCallback;
-    private ImageView mChooseMore;
     private Map<Behavior, ArrayList<Action>> mBehaviorActionMap = new HashMap<Behavior,
             ArrayList<Action>>();
     private Boolean reloadData = true;
@@ -92,13 +89,6 @@ public class GoalDetailsFragment extends Fragment implements
                              Bundle savedInstanceState) {
         View v = getActivity().getLayoutInflater().inflate(
                 R.layout.fragment_goal_details, container, false);
-        mChooseMore = (ImageView) v.findViewById(R.id.goal_choose_more_imageview);
-        mChooseMore.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showPopup();
-            }
-        });
 
         TextView titleTextView = (TextView) v.findViewById(R.id.goal_title_textview);
         titleTextView.setText(mGoal.getTitle());
@@ -107,7 +97,7 @@ public class GoalDetailsFragment extends Fragment implements
         goalManagementLabel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mCallback.learnMoreGoal(mGoal);
+                mCallback.chooseBehaviors(mGoal);
             }
         });
 
@@ -225,24 +215,6 @@ public class GoalDetailsFragment extends Fragment implements
         }
     }
 
-    private void showPopup() {
-        //Creating the instance of PopupMenu
-        CompassPopupMenu popup = CompassPopupMenu.newInstance(getActivity(), mChooseMore);
-        popup.getMenuInflater().inflate(R.menu.menu_goal_details, popup.getMenu());
-        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
-            public boolean onMenuItemClick(MenuItem item) {
-                switch (item.getItemId()) {
-                    case R.id.menu_popup_add_behavior:
-                        mCallback.chooseBehaviors(mGoal);
-                        break;
-                    case R.id.menu_popup_remove_goal:
-                        mCallback.deleteGoal(mGoal);
-                }
-                return true;
-            }
-        });
-        popup.show();
-    }
 
     @Override
     public void deleteUserBehavior(Behavior behavior) {

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -10,7 +10,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -22,6 +21,7 @@ import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.task.AddActionTask;
 import org.tndata.android.compass.task.DeleteActionTask;
+import org.tndata.android.compass.ui.CompassPopupMenu;
 import org.tndata.android.compass.util.ImageHelper;
 
 import java.util.ArrayList;
@@ -255,7 +255,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
     }
 
     private void showPopup() {
-        PopupMenu popup = new PopupMenu(getActivity(), mAddImageView);
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(getActivity(), mAddImageView);
         // Inflating the correct menu depending on which kind of content we're viewing.
         if(mAction != null) {
             popup.getMenuInflater()
@@ -264,7 +264,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
             popup.getMenuInflater().inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
         }
 
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_remove_item:

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -79,6 +79,10 @@ public class Category extends TDCBase implements Serializable,
         this.goals = goals;
     }
 
+    public void removeGoal(Goal goal) {
+        this.goals.remove(goal);
+    }
+
     public String getColor() {
         return color;
     }

--- a/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
+++ b/src/main/java/org/tndata/android/compass/ui/ActionCellView.java
@@ -7,7 +7,6 @@ import android.util.AttributeSet;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -92,13 +91,13 @@ public class ActionCellView extends RelativeLayout implements AddActionTask
 
     private void showPopup() {
         //Creating the instance of PopupMenu
-        PopupMenu popup = new PopupMenu(mContext, mAddImageView);
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(mContext, mAddImageView);
         //Inflating the Popup using xml file
         popup.getMenuInflater()
                 .inflate(R.menu.menu_action_popup_chooser, popup.getMenu());
 
         //registering popup with OnMenuItemClickListener
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_popup_remove_item:

--- a/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
+++ b/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
@@ -6,7 +6,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import org.tndata.android.compass.R;
@@ -85,10 +84,10 @@ public class BehaviorListView extends LinearLayout {
 
     private void showPopup() {
         //Creating the instance of PopupMenu
-        PopupMenu popup = new PopupMenu(mContext, mAddImageView);
+        CompassPopupMenu popup = CompassPopupMenu.newInstance(mContext, mAddImageView);
         popup.getMenuInflater()
                 .inflate(R.menu.menu_behavior_popup_chooser, popup.getMenu());
-        popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+        popup.setOnMenuItemClickListener(new CompassPopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
                 switch (item.getItemId()) {
                     case R.id.menu_behavior_popup_remove_item:

--- a/src/main/java/org/tndata/android/compass/ui/CompassPopupMenu.java
+++ b/src/main/java/org/tndata/android/compass/ui/CompassPopupMenu.java
@@ -1,0 +1,31 @@
+package org.tndata.android.compass.ui;
+
+import android.content.Context;
+import android.os.Build;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.PopupMenu;
+
+public class CompassPopupMenu extends PopupMenu {
+
+    private static final String TAG = "CompassPopupMenu";
+
+    public CompassPopupMenu(Context context, View anchor) {super(context, anchor);}
+
+    public CompassPopupMenu(Context context, View anchor, int gravity) {
+        // Android Studio complains about this requiring API level 19 and our
+        // minimum being 14, but with the factory method, should be ok.
+        super(context, anchor, gravity);
+    }
+
+    public static CompassPopupMenu newInstance(Context context, View anchor) {
+        CompassPopupMenu popup;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            // TODO: This doesn't actually seem to change where the popup menu appears :(
+            popup = new CompassPopupMenu(context, anchor, Gravity.CENTER);
+        } else {
+            popup = new CompassPopupMenu(context, anchor);
+        }
+        return popup;
+    }
+}

--- a/src/main/res/layout/fragment_goal_details.xml
+++ b/src/main/res/layout/fragment_goal_details.xml
@@ -57,16 +57,6 @@
                 android:textColor="@color/dark_text_color"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
 
-            <ImageView
-                android:id="@+id/goal_choose_more_imageview"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_margin="0dp"
-                android:padding="0dp"
-                android:src="@drawable/ic_more_vert"
-                android:layout_centerVertical="true" />
-
         </RelativeLayout>
 
         <View

--- a/src/main/res/layout/list_item_category_goal.xml
+++ b/src/main/res/layout/list_item_category_goal.xml
@@ -92,7 +92,7 @@
             android:visibility="gone" />
 
         <TextView
-            android:id="@+id/list_item_category_goal_more_info_button"
+            android:id="@+id/list_item_category_goal_more_info_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="right"

--- a/src/main/res/layout/list_item_category_goal.xml
+++ b/src/main/res/layout/list_item_category_goal.xml
@@ -20,43 +20,63 @@
         android:paddingTop="5dp"
         android:orientation="vertical">
 
-        <LinearLayout
-            android:id="@+id/list_item_category_goal_goal_container"
+        <RelativeLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_margin="5dp">
+            android:layout_height="wrap_content">
 
-            <RelativeLayout
-                android:id="@+id/list_item_category_goal_circle_view"
-                android:layout_width="@dimen/goal_icon_image_size"
-                android:layout_height="@dimen/goal_icon_image_size"
-                android:layout_margin="10dp"
-                android:padding="10dp"
-                android:gravity="center_vertical"
-                android:layout_gravity="center_vertical"
-                android:contentDescription="@string/goal_image_description"
-                android:background="@drawable/circle">
-
-                <ImageView
-                    android:id="@+id/list_item_category_goal_icon_imageview"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:layout_centerInParent="true"/>
-            </RelativeLayout>
-
-            <TextView
-                android:id="@+id/list_item_category_goal_title_textview"
+            <LinearLayout
+                android:id="@+id/list_item_category_goal_goal_container"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="5dp"
-                android:paddingLeft="2dp"
-                android:gravity="center_vertical"
-                android:layout_gravity="center_vertical"
-                android:textColor="@color/dark_text_color"
-                android:textAppearance="?android:attr/textAppearanceMedium"/>
-        </LinearLayout>
+                android:orientation="horizontal"
+                android:layout_margin="5dp">
+
+                <RelativeLayout
+                    android:id="@+id/list_item_category_goal_circle_view"
+                    android:layout_width="@dimen/goal_icon_image_size"
+                    android:layout_height="@dimen/goal_icon_image_size"
+                    android:layout_margin="10dp"
+                    android:padding="10dp"
+                    android:gravity="center_vertical"
+                    android:layout_gravity="center_vertical"
+                    android:contentDescription="@string/goal_image_description"
+                    android:background="@drawable/circle">
+
+                    <ImageView
+                        android:id="@+id/list_item_category_goal_icon_imageview"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="10dp"
+                        android:layout_centerInParent="true"/>
+                </RelativeLayout>
+
+                <TextView
+                    android:id="@+id/list_item_category_goal_title_textview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="5dp"
+                    android:paddingLeft="2dp"
+                    android:gravity="center_vertical"
+                    android:layout_gravity="center_vertical"
+                    android:textColor="@color/dark_text_color"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+
+
+            </LinearLayout>
+
+            <ImageView
+                android:id="@+id/goal_popup_imageview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentRight="true"
+                android:layout_margin="0dp"
+                android:padding="0dp"
+                android:src="@drawable/ic_more_vert"
+                android:contentDescription="@string/popup_menu_content_description" />
+
+        </RelativeLayout>
 
         <TextView
             android:id="@+id/list_item_category_goal_description_textview"
@@ -69,26 +89,23 @@
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:singleLine="false"
             android:gravity="left"
-            android:visibility="gone"/>
+            android:visibility="gone" />
 
-        <Button
+        <TextView
             android:id="@+id/list_item_category_goal_more_info_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
             android:layout_gravity="right"
-            android:layout_margin="15dp"
+            android:gravity="center"
+            android:layout_margin="10dp"
             android:minHeight="@dimen/paper_flat_button_min_height"
-            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textAppearance="?android:attr/textAppearanceSmall"
             android:textColor="@color/grow_primary"
-            android:text="@string/learn_more_title_label"
-            android:background="@color/white"
-            android:elevation="0dp"
-            android:elegantTextHeight="false"
+            android:text="@string/goal_card_details_label"
             android:paddingLeft="10dp"
             android:paddingRight="10dp"
             android:singleLine="true"
-            android:textColorHighlight="@color/white"
-            android:visibility="gone"/>
+            android:visibility="gone" />
+
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/src/main/res/menu/menu_goal_details.xml
+++ b/src/main/res/menu/menu_goal_details.xml
@@ -6,6 +6,10 @@
         android:title="@string/menu_goal_new_behaviors"/>
 
     <item
+        android:id="@+id/menu_popup_view_details"
+        android:title="@string/menu_goal_view_details"/>
+
+    <item
         android:id="@+id/menu_popup_remove_goal"
         android:title="@string/menu_goal_remove"/>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="goal_deleted">Goal Deleted</string>
     <string name="goal_card_details_label">MORE INFO</string>
 
+    <!-- CategoryFragment -->
+    <string name="goal_dialog_delete_title">Delete Goal?</string>
+    <string name="goal_dialog_delete_message">You are about to permanently remove this</string>
+
     <!-- Time/Recurrence pickers -->
     <string name="time_picker_confirmation_toast">You have selected %1$s</string>
     <string name="recurrence_picker_confirmation_toast">Reminder Saved!</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -87,8 +87,8 @@
     <string name="more_info_header">More Information</string>
 
     <!-- GoalDetailsActivity -->
-    <string name="goal_title_label">Achieve Your Goal</string>
-    <string name="goal_management">Achieve your Goal</string>
+    <string name="goal_title_label">Your Goal</string>
+    <string name="goal_management">Find more Activities</string>
     <string name="menu_goal_new_behaviors">Choose Priorities</string>
     <string name="menu_goal_view_details">View Details</string>
     <string name="menu_goal_remove">Remove Goal</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="action_my_privacy">My Privacy</string>
     <string name="nav_drawer_action">Compass</string>
     <string name="main_tab_title">My Journey</string>
+    <string name="popup_menu_content_description">View More Options</string>
+    <string name="goal_deleted">Goal Deleted</string>
 
     <!-- Time/Recurrence pickers -->
     <string name="time_picker_confirmation_toast">You have selected %1$s</string>
@@ -87,6 +89,7 @@
     <string name="goal_title_label">Achieve Your Goal</string>
     <string name="goal_management">Achieve your Goal</string>
     <string name="menu_goal_new_behaviors">Choose New Priorities</string>
+    <string name="menu_goal_view_details">View Details</string>
     <string name="menu_goal_remove">Remove Goal</string>
 
     <!-- BehaviorActivity -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -13,11 +13,11 @@
     <string name="action_my_privacy">My Privacy</string>
     <string name="nav_drawer_action">Compass</string>
     <string name="main_tab_title">My Journey</string>
+
+    <!-- CategoryFragment -->
     <string name="popup_menu_content_description">View More Options</string>
     <string name="goal_deleted">Goal Deleted</string>
     <string name="goal_card_details_label">MORE INFO</string>
-
-    <!-- CategoryFragment -->
     <string name="goal_dialog_delete_title">Delete Goal?</string>
     <string name="goal_dialog_delete_message">You are about to permanently remove this</string>
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="main_tab_title">My Journey</string>
     <string name="popup_menu_content_description">View More Options</string>
     <string name="goal_deleted">Goal Deleted</string>
+    <string name="goal_card_details_label">MORE INFO</string>
 
     <!-- Time/Recurrence pickers -->
     <string name="time_picker_confirmation_toast">You have selected %1$s</string>
@@ -88,7 +89,7 @@
     <!-- GoalDetailsActivity -->
     <string name="goal_title_label">Achieve Your Goal</string>
     <string name="goal_management">Achieve your Goal</string>
-    <string name="menu_goal_new_behaviors">Choose New Priorities</string>
+    <string name="menu_goal_new_behaviors">Choose Priorities</string>
     <string name="menu_goal_view_details">View Details</string>
     <string name="menu_goal_remove">Remove Goal</string>
 


### PR DESCRIPTION
We want to let the user manage their goals without having to drill completely down into the `GoalDetailsActivity`, so I've added a popup menu/vertical ellipsis icon back on the Goal Cards.

This PR also adds the following updates to the `GoalDetailsFragment`:

- removes the goal-related popup
- launches the behavior picker (`GoalTryActivity`), instead