### PR TITLE
Fall back to Default Trigger/Misc Bug Fixes

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ActionTriggerActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionTriggerActivity.java
@@ -35,7 +35,7 @@ public class ActionTriggerActivity extends BaseTriggerActivity implements
         mAction = (Action) getIntent().getSerializableExtra("action");
 
         // Initialize the reminder data
-        initializeReminders(mAction.getCustomTrigger());
+        initializeReminders(mAction.getTrigger());
 
         setContentView(R.layout.activity_base);
 

--- a/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
@@ -61,10 +61,14 @@ public class BaseTriggerActivity extends ActionBarActivity implements
 
     public void initializeReminders(Trigger trigger) {
         // initialize local vars with a given Trigger
-        String time = trigger.getTime();
-        String date = trigger.getDate();
-        String rrule = trigger.getRRULE();
-        initializeReminders(time, date, rrule);
+        if(trigger != null) {
+            String time = trigger.getTime();
+            String date = trigger.getDate();
+            String rrule = trigger.getRRULE();
+            initializeReminders(time, date, rrule);
+        } else {
+            initializeReminders("", "", "");
+        }
     }
 
     public void initializeReminders(String time, String date, String rrule) {

--- a/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BaseTriggerActivity.java
@@ -259,7 +259,7 @@ public class BaseTriggerActivity extends ActionBarActivity implements
         // action is the updated Action, presumably with a Trigger attached.
         if(action != null) {
             Log.d(TAG, "Updated Action: " + action.getTitle());
-            Log.d(TAG, "Updated Trigger: " + action.getCustomTrigger());
+            Log.d(TAG, "Updated Trigger: " + action.getTrigger());
             Toast.makeText(this,
                     getText(R.string.trigger_saved_confirmation_toast),
                     Toast.LENGTH_SHORT).show();

--- a/src/main/java/org/tndata/android/compass/fragment/ActionTriggerFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/ActionTriggerFragment.java
@@ -80,7 +80,7 @@ public class ActionTriggerFragment extends Fragment {
                              Bundle savedInstanceState) {
 
         // TODO: update text views with the default trigger info if there's no custom trigger
-        final Trigger trigger = mAction.getCustomTrigger();
+        final Trigger trigger = mAction.getTrigger();
 
         View v = getActivity().getLayoutInflater().inflate(
                 R.layout.fragment_action_trigger, container, false);

--- a/src/main/java/org/tndata/android/compass/fragment/ActionTriggerFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/ActionTriggerFragment.java
@@ -89,7 +89,7 @@ public class ActionTriggerFragment extends Fragment {
         titleTextView.setText(mAction.getTitle());
 
         Switch notificationSwitch = (Switch) v.findViewById(R.id.notification_option_switch);
-        if(trigger.isDisabled()) {
+        if(trigger != null && trigger.isDisabled()) {
             notificationSwitch.setChecked(false);
         }
         notificationSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -160,7 +160,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
 
             // Display different content in the "Add this" label when the user
             // has already selected the item.
-            Trigger trigger = mAction.getCustomTrigger();
+            Trigger trigger = mAction.getTrigger();
             if(trigger != null) {
                 // Construct a string for the Action's Label
                 String recurrence = trigger.getRecurrencesDisplay();

--- a/src/main/java/org/tndata/android/compass/model/Action.java
+++ b/src/main/java/org/tndata/android/compass/model/Action.java
@@ -119,6 +119,15 @@ public class Action extends TDCBase implements Serializable, Comparable<Action> 
         this.behavior_id = behavior_id;
     }
 
+    public Trigger getTrigger() {
+        // Return the custom trigger if it exists, otherwise return the default trigger.
+        if(custom_trigger != null) {
+            return custom_trigger;
+        }else{
+            return default_trigger;
+        }
+    }
+
     public Trigger getCustomTrigger() {
         return custom_trigger;
     }

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -89,7 +89,7 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
                     action.setCustomTrigger(
                             gson.fromJson(userAction.getString("custom_trigger"), Trigger.class));
 
-                    Log.d("TRIGGER", "loaded trigger: " + action.getCustomTrigger().getName());
+                    Log.d("TRIGGER", "loaded trigger: " + action.getTrigger().getName());
                 }
             }
             return actions;


### PR DESCRIPTION
Ensure that we fall back to the default trigger when opening the reminder/notification screen.  Also, don't call methods on null objects.