### PR TITLE
Always send the registration id to the backend

### DIFF
--- a/src/main/java/org/tndata/android/compass/task/RegisterDeviceTask.java
+++ b/src/main/java/org/tndata/android/compass/task/RegisterDeviceTask.java
@@ -3,6 +3,7 @@ package org.tndata.android.compass.task;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.Html;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -38,6 +39,7 @@ public class RegisterDeviceTask extends AsyncTask<Void, Void, Void> {
         String token = ((CompassApplication) (mContext)).getToken();
         String url = Constants.BASE_URL + "notifications/devices/";
 
+        Log.d(TAG, "POSTing to: " + url);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Accept", "application/json");
         headers.put("Content-type", "application/json");
@@ -54,6 +56,7 @@ public class RegisterDeviceTask extends AsyncTask<Void, Void, Void> {
         InputStream stream = NetworkHelper.httpPostStream(url, headers,
                 body.toString());
         if (stream == null) {
+            Log.d(TAG, "----> null response");
             return null;
         }
         String result = "";
@@ -68,6 +71,8 @@ public class RegisterDeviceTask extends AsyncTask<Void, Void, Void> {
                 result += line;
             }
             bReader.close();
+
+            Log.d(TAG, "result: " + result);
 
             createResponse = Html.fromHtml(result).toString();
             JSONObject device = new JSONObject(createResponse);

--- a/src/main/java/org/tndata/android/compass/util/GcmRegistration.java
+++ b/src/main/java/org/tndata/android/compass/util/GcmRegistration.java
@@ -41,6 +41,9 @@ public class GcmRegistration implements RegisterDeviceTask.RegisterDeviceTaskLis
 
             if (registration_id.isEmpty()) {
                 registerInBackground();
+            } else {
+                // Always update this.
+                sendRegistrationIdToBackend(registration_id);
             }
         } else {
             Log.i(TAG, "No valid Google Play Services APK found.");


### PR DESCRIPTION
We'd periodically had users who didn't have a registered device for some reason, so I want to always send that info to the backend so we can deliver notifications.

POSTing this data if it already exists will return a 301 Not Modified result.